### PR TITLE
Fixed typo in DE: herunterlanden -> herunterladen (downland -> download)

### DIFF
--- a/i18n/de/LC_MESSAGES/sphinx.po
+++ b/i18n/de/LC_MESSAGES/sphinx.po
@@ -494,7 +494,7 @@ msgstr "Für Ihren Desktop, Server, im Webbrowser und als\n          Bibliothek 
 
 #: ../../themes/qgis-theme/index.html:85
 msgid "Download Now"
-msgstr "Jetzt herunterlanden"
+msgstr "Jetzt herunterladen"
 
 #: ../../themes/qgis-theme/index.html:116
 msgid "Get Started"


### PR DESCRIPTION
....
