### PR TITLE
Fix link to roadmap

### DIFF
--- a/themes/qgis-theme/getinvolved_index.html
+++ b/themes/qgis-theme/getinvolved_index.html
@@ -109,7 +109,7 @@
                     <a href="{{ pathto('site/getinvolved/development/index') }}">{{ _('Get Set Up for QGIS Core Development') }}</a>
                 </h4>
                 <h4 class="subsection-link">
-                    <a href="{{ pathto('site/getinvolved/development/index#road-map') }}">{{ _('QGIS roadmap') }}</a>
+                    <a href="{{ pathto('site/getinvolved/development/index') }}#road-map">{{ _('QGIS roadmap') }}</a>
                 </h4>
             </div>
             <div class="span1"></div>


### PR DESCRIPTION
Current link references the anchor incorrectly and therefore just jumps to page and not to paragraph
