### PR TITLE
Changed header for consistency

### DIFF
--- a/themes/qgis-theme/getinvolved_index.html
+++ b/themes/qgis-theme/getinvolved_index.html
@@ -1,4 +1,3 @@
-
 <div class="getinvolved" id="color-identifier"></div>
 
 <section class="sub-landing-page" id="top">
@@ -39,7 +38,7 @@
                             <a href="#plugin">{{ _('Develop a Plugin') }}</a>
                         </li>
                         <li>
-                            <a href="#core">{{ _('QGIS Core Development') }}</a>
+                            <a href="#core">{{ _('Develop QGIS Core') }}</a>
                         </li>
                         <li>
                             <a href="#bugs">{{ _('Report Bugs') }}</a>
@@ -103,7 +102,7 @@
             </div>
             <div class="span1"></div>
             <div class="span5">
-                <h3>{{ _('QGIS Core Development') }}</h3>
+                <h3>{{ _('Develop QGIS Core') }}</h3>
                 <p>{{ _('QGIS Core consists on the one hand of the libraries enabling you to build custom tailored application by  providing a powerful API. On the other hand it consists of a desktop and server application which expose the possibilities offered by the libraries, offering a user friendly interface.') }}</p>
                 <h4 class="subsection-link">
                     <a href="{{ pathto('site/getinvolved/development/index') }}">{{ _('Get Set Up for QGIS Core Development') }}</a>


### PR DESCRIPTION
Changed "QGIS Core Development" to "Develop QGIS Core" to be consistent with the style of the other items.
