### PR TITLE
replace Quantum GIS with QGIS, split long lines

### DIFF
--- a/source/site/about/case_studies/antarctica.rst
+++ b/source/site/about/case_studies/antarctica.rst
@@ -1,9 +1,14 @@
 
 ======================================
-Quantarctica: An Antarctic GIS package 
+Quantarctica: An Antarctic GIS package
 ======================================
 
-Quantarctica is a collection of Antarctic geographical datasets, such as base maps, satellite imagery, glaciology and geophysics data from data centres around the world, prepared for viewing in Quantum GIS (QGIS). The package is developed by the Norwegian Polar Institute, as a tool for the research community, for classrooms and for operational use in Antarctica – freely available for non-commercial purposes.
+Quantarctica is a collection of Antarctic geographical datasets, such as base
+maps, satellite imagery, glaciology and geophysics data from data centres
+around the world, prepared for viewing in QGIS. The package is developed by
+the Norwegian Polar Institute, as a tool for the research community, for
+classrooms and for operational use in Antarctica –-- freely available for
+non-commercial purposes.
 
 About the project
 =================
@@ -12,24 +17,42 @@ About the project
    :alt: Screenshot from Quantarctica, showing one of the subglacial lakes datasets.
    :scale: 90%
    :align: right
-   
+
    Screenshot from Quantarctica, showing one of the subglacial lakes datasets.
 
 
-Quantarctica (Quantum GIS + Antarctica) was first developed for in-house use at the Norwegian Polar Institute, as a tool for our glaciologists. There was a need for a low or no cost complete GIS with essential datasets – ready-to-use, easy-to-use, functionality rich and with offline capabilities. QGIS seemed to be a perfect choice of GIS for the collected datasets.
+Quantarctica (QGIS + Antarctica) was first developed for in-house use at the
+Norwegian Polar Institute, as a tool for our glaciologists. There was a need
+for a low or no cost complete GIS with essential datasets –-- ready-to-use,
+easy-to-use, functionality rich and with offline capabilities. QGIS seemed to
+be a perfect choice of GIS for the collected datasets.
 
-Quantarctica has been used to examine geographical data from continental to local scales, for viewing scientific project data on top of base maps or with other scientific datasets, and to prepare maps for publications and proposals. Quantarctica has so far proven to be a great tool, and a very good alternative and supplement to other software used by the researchers. It has provided new opportunities for our researchers in their daily work.
+Quantarctica has been used to examine geographical data from continental to
+local scales, for viewing scientific project data on top of base maps or with
+other scientific datasets, and to prepare maps for publications and proposals.
+Quantarctica has so far proven to be a great tool, and a very good alternative
+and supplement to other software used by the researchers. It has provided new
+opportunities for our researchers in their daily work.
 
 .. figure:: ./images/quantarctica2.jpg
    :alt: Quantarctica is also useful when navigating on the Antarctic ice shelves thanks to the GPS tracking capabilities within QGIS.
    :scale: 100%
    :align: left
-   
-   Quantarctica is also useful when navigating on the Antarctic ice shelves thanks to the GPS tracking capabilities within QGIS.
 
-Since Quantarctica first came in use by our glaciologists three years ago, there has been many requests in the research community outside the institute to share this product, and we started to develop a public and improved version to replace the in-house version. Following Antarctic field testing, and adding new relevant datasets, Quantarctica version 1.0 was finally completed and made available for download in July 2013.
+   Quantarctica is also useful when navigating on the Antarctic ice shelves
+   thanks to the GPS tracking capabilities within QGIS.
 
-Quantarctica is to be all about community effort. With contributions we aim to expand with data from other disciplines, such as oceanography, atmospheric sciences, geology and biology, and hope and believe that this tool can be useful for the Antarctic community – as a complete Antarctic GIS package.
+Since Quantarctica first came in use by our glaciologists three years ago,
+there has been many requests in the research community outside the institute
+to share this product, and we started to develop a public and improved version
+to replace the in-house version. Following Antarctic field testing, and adding
+new relevant datasets, Quantarctica version 1.0 was finally completed and made
+available for download in July 2013.
+
+Quantarctica is to be all about community effort. With contributions we aim to
+expand with data from other disciplines, such as oceanography, atmospheric
+sciences, geology and biology, and hope and believe that this tool can be
+useful for the Antarctic community –-- as a complete Antarctic GIS package.
 
 Links
 =====
@@ -47,5 +70,7 @@ Authors
 
    Anders Skoglund and Kenichi Matsuoka
 
-This article was contributed in August 2013 by Anders Skoglund (left), GIS specialist, and Kenichi Matsuoka (right), glaciologist, both at the Norwegian Polar Institute.
+This article was contributed in August 2013 by Anders Skoglund (left), GIS
+specialist, and Kenichi Matsuoka (right), glaciologist, both at the Norwegian
+Polar Institute.
 

--- a/source/site/getinvolved/governance/developer_meetings/reimbursements.rst
+++ b/source/site/getinvolved/governance/developer_meetings/reimbursements.rst
@@ -2,7 +2,7 @@
 Reimbursements for Developer Meetings
 *************************************
 
-The Quantum GIS project holds twice-yearly developer meetings, typically somewhere
+The QGIS project holds twice-yearly developer meetings, typically somewhere
 in Europe. The purpose of the meetings is to provide face-to-face time for
 developers. It is a forum for presenting new ideas, planning, putting heads
 together to solve problems and so on. We use funding from our :doc:`../sponsorship/index`
@@ -33,7 +33,7 @@ Policy for disbursement of funds to individual developers
   by the PSC shall be final.
 * Individual applications from non-core developers (i.e. those who do not have
   direct commit access to the QGIS repositories) of EUR200 or less may be
-  decided on by the nominated PSC member without requiring a full PSC vote. 
+  decided on by the nominated PSC member without requiring a full PSC vote.
 * Individual applications from core-developers may be granted based on
   precident directly by the PSC Financial Representative (Paolo Cavallini). In
   the event of any uncertainty on his part, he may bring the matter to the PSC
@@ -43,7 +43,7 @@ Policy for disbursement of funds to individual developers
   will be provided on a first-come first-served basis.
 * The PSC / PSC Finance Chair may offer to provide partial funding where
   funding resources are limited.
-* The PSC Financial Chair shall maintain complete financial records of what 
+* The PSC Financial Chair shall maintain complete financial records of what
   disbursements were made and to whom and these should be available on request
   to the PSC.
 
@@ -64,11 +64,11 @@ Procedure for funding applications - core developers
 Procedure for funding applications - new developers
 ---------------------------------------------------
 
-* A request for funding email should be submitted to the PSC Member designated to 
+* A request for funding email should be submitted to the PSC Member designated to
   review funding requests **before** the meeting.
 * If the requestor is not happy with the funding requests reviewer's decision, they
   may request arbitration from the PSC as a whole.
-* The request should include a **workplan** outlining how the developer plans to 
+* The request should include a **workplan** outlining how the developer plans to
   make use of their time at the meeting.
 * The request should include the number of days that the developer will attend.
 * The request should include an expense breakdown covering travel and

--- a/source/site/getinvolved/governance/sponsorship/sponsorship.rst
+++ b/source/site/getinvolved/governance/sponsorship/sponsorship.rst
@@ -44,8 +44,8 @@ donation is a once off financial contribution to the QGIS project.
 Sponsorship
 -----------
 
-Sponsors can sponsor Quantum GIS for any amount of money of at least 500 €/700
-US$. Sponsorships last one year, after which they may be continued with a new
+Sponsors can sponsor QGIS for any amount of money of at least 500 €/700 US$.
+Sponsorships last one year, after which they may be continued with a new
 payment, or allowed to lapse. At or above the following levels a sponsor will
 be designated as being one of the following class:
 
@@ -72,7 +72,7 @@ the bank account rather than PayPal.
 What is your benefit sponsoring the QGIS Development?
 =====================================================
 
-Sponsoring the Quantum GIS project provides the following benefits:
+Sponsoring the QGIS project provides the following benefits:
 
 * Ensures the sustainability and health of the QGIS project.
 * All sponsors will be listed on the project sponsor page, ordered by


### PR DESCRIPTION
This will completely (I hope) fix issues with re-branding (QuantumGIS → QGIS).
Also some too long lines reformatted to fit 80 characters width.
