### PR TITLE
Update qugsnews.atom

### DIFF
--- a/source/feeds/qugsnews.atom
+++ b/source/feeds/qugsnews.atom
@@ -34,6 +34,17 @@
     <content type="text">12th QGIS Developer Meeting in Essen (Linuxhotel)</content>
   </entry>
 
+  <entry>
+    <id>http://qgis.org</id>
+    <title type="text">October 6th</title>
+    <link href="http://www.meetup.com/qgis_us/Atlanta-QGIS-Users-Group/1183222/" rel="alternate"> </link>
+    <author> <name>No Author</name> </author>
+    <updated>1970-01-01T00:00:00.000Z</updated>
+    <content type="text">Atlanta QGIS User Group at the Georgia Geospatial Conference</content>
+  </entry>
+
+
+
   <!--<entry>
     <id>http://qgis.org</id>
     <title type="text">トキオQGISユーザーグループ</title>


### PR DESCRIPTION
added Atlanta QGIS User Group at the Georgia Geospatial Conference
