### PR TITLE
Fix broken link to INSTALL file on GitHub

### DIFF
--- a/source/site/getinvolved/development/index.rst
+++ b/source/site/getinvolved/development/index.rst
@@ -214,7 +214,7 @@ http://qgis.org/api/2.0/classQgisInterface.html (for QGIS 2.0)
 
 http://qgis.org/api/1.8/classQgisInterface.html (for QGIS 1.8)
 
-.. _INSTALL: http://htmlpreview.github.io/?http://github.com/qgis/QGIS/blob/master/doc/INSTALL.html
+.. _INSTALL: http://htmlpreview.github.io/?https://github.com/qgis/QGIS/blob/master/doc/INSTALL.html
 
 Adding GRASS tools
 ------------------


### PR DESCRIPTION
Needed to be https not http.
Note this is my first ever github, git, and qgis change--bear with me if there's a mistake in process.
