### PR TITLE
Added foss4g2015 logo to front page

### DIFF
--- a/themes/qgis-theme/index.html
+++ b/themes/qgis-theme/index.html
@@ -146,6 +146,13 @@
       <!--  </div> -->
           </p>
         </div>
+	<div class="span12">
+            <p>
+                <a href="http://2015.foss4g.org/">
+                    <img src="https://foss4g2015.files.wordpress.com/2014/11/foss4g2015_a1_300x1252.png" alt="FOSS4G2015_logo" width="300" height="125">
+                </a>
+            </p>
+        </div>
     </div>
 </section>
 


### PR DESCRIPTION
One drawback of our site layout is that its difficult to put stuff like this 'above the fold' anyway hopefully this will help...

![selection_021](https://cloud.githubusercontent.com/assets/178003/5001603/226e3d5a-6a00-11e4-9dcf-d822032f21b0.jpg)
# CC

@jmckenna
@rduivenvoorde 
