### PR TITLE
removed "documentation"

### DIFF
--- a/themes/qgis-theme/forusers_index.html
+++ b/themes/qgis-theme/forusers_index.html
@@ -31,9 +31,6 @@
                             <a href="#plugins">{{ _('QGIS Plugins') }}</a>
                         </li>
                         <li>
-                            <a href="#docs">{{ _('Documentation') }}</a>
-                        </li>
-                        <li>
                             <a href="#trainingmaterial">{{ _('Training material') }}</a>
                         </li>
                         <li>
@@ -101,28 +98,6 @@
             <div class="span1"></div>
             <div class="span4">
                 <img src='../../_static/images/users-plugins.png' class="text-center background-mask non-mobile-image wd" alt="plugins puzzle icon" />
-            </div>
-            <div class="span1"></div>
-        </div>
-        <hr>
-        <div class="row-fluid" id="docs">
-            <div class="offset1 span4">
-                <img src='../../_static/images/users-docs.png' class="text-center background-mask non-mobile-image wd" alt="docs icon" />
-            </div>
-            <div class="span1"></div>
-            <div class="span5">
-                <h3>{{ _('QGIS Documentation') }}</h3>
-                <p>{{ _('The User manual contains all documentation needed for a user to get started. The documentation is updated with every update of QGIS.') }}
-                </p>
-                <h4>
-                    <a href="http://docs.qgis.org/{{version}}/{{language}}/docs/user_manual/index.html">{{ _('Read QGIS Documentation') }}</a>
-                </h4>
-                <p>{{ _('Another good guide to getting started is:') }}
-                </p>
-                <h4>
-                    <a href="http://docs.qgis.org/{{version}}/{{language}}/docs/gentle_gis_introduction/index.html">{{ _('A Gentle Introduction to GIS') }}</a>
-                </h4>
-
             </div>
             <div class="span1"></div>
         </div>


### PR DESCRIPTION
visitors can already access the documentation via the main menu at the top. no use to further clutter the page and having to update links.
