### PR TITLE
removed artificially blowing up flickr thumbnails

### DIFF
--- a/themes/qgis-theme/static/qgis-style.css
+++ b/themes/qgis-theme/static/qgis-style.css
@@ -533,7 +533,7 @@ section.latest-news p.intro {
   clear: both;
 }
 .span3 img.flickrimg {
-  width: 230px;
+  width: 150px;
 }
 section.sponsors {
   padding: 30px 0;


### PR DESCRIPTION
Blowing up the 150x150px thumbnails to 230x230px just makes them look bad. Unfortunalty, it doesn't seem possible to request bigger square thumbs from Flickr.
