### PR TITLE
description of contributors link in github

### DIFF
--- a/source/site/getinvolved/governance/governance.rst
+++ b/source/site/getinvolved/governance/governance.rst
@@ -172,6 +172,8 @@ These `individuals <https://github.com/qgis/QGIS/graphs/contributors>`_
 are recognised as Contributors to the main code
 `github repository <https://github.com/qgis/QGIS>`_.
 
+Follow the lists of maintainers of the `documentation <https://github.com/qgis/QGIS-Documentation/graphs/contributors>`_ and the `website <https://github.com/qgis/QGIS-Website/graphs/contributors>`_. Feel free to join any of those teams.
+
 ..
    TODO : add list of translators, bug reporters (is that possible?)
   

--- a/source/site/getinvolved/governance/governance.rst
+++ b/source/site/getinvolved/governance/governance.rst
@@ -166,8 +166,12 @@ members write code or documentation, while others are valuable as testers,
 submitting patches and suggestions.
 
 The number of Contributors to the project is unbounded. Get involved today.
-All contributions to the project are greatly appreciated.
+All contributions (adding code or documentation, fixing typo error, reporting issues...) to the project are greatly appreciated.
 
-This `individuals <https://github.com/qgis/QGIS/graphs/contributors>`_
-are recognised as Project Committers and have full commit access to the
+These `individuals <https://github.com/qgis/QGIS/graphs/contributors>`_
+are recognised as Contributors to the main code
 `github repository <https://github.com/qgis/QGIS>`_.
+
+..
+   TODO : add list of translators, bug reporters (is that possible?)
+  


### PR DESCRIPTION
The link shows all the contributors to the qgis github repo not just those who have commit rights
