### PR TITLE
replace unused markup with explanatory comment

### DIFF
--- a/source/docs/index.rst
+++ b/source/docs/index.rst
@@ -1,77 +1,9 @@
-
-
-.. Documentation frontpage intro text !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-
-.. rst-class:: frontpageintro
-
 Documentation
 =============
 
-
-QGIS has a lot of documentation, partly translated. Please have a look into one 
-of the documents below.
-
-Documentation for QGIS 2.2
---------------------------
+.. note
+    Body of this file is not used, it is overridden by themes/qgis-theme/docs_index.html.
+    We put a toctree here just to have these pages in a toc, thereby in the tocbar
 
 .. toctree::
-   :maxdepth: 1
-
-   User guide/Manual <http://docs.qgis.org/2.2/en/docs/user_manual>
-   PyQGIS cookbook <http://docs.qgis.org/2.2/en/docs/pyqgis_developer_cookbook>
-   Documentation Guidelines (how to write the docs)<http://docs.qgis.org/2.2/en/docs/documentation_guidelines>
-   A gentle introduction in GIS <http://docs.qgis.org/2.2/en/docs/gentle_gis_introduction/>
-   PDF versions for printing <http://docs.qgis.org/2.2/pdf>
-   Trainings manual <http://docs.qgis.org/2.2/en/docs/training_manual/>
-
-
-Documentation for QGIS 2.0
---------------------------
-
-We keep a copy of the documentation of QGIS 2.0 around here: http://docs.qgis.org/2.0
-
-.. toctree::
-   :maxdepth: 1
-
-   User guide/Manual <http://docs.qgis.org/2.0/en/docs/user_manual>
-   PyQGIS cookbook <http://docs.qgis.org/2.0/en/docs/pyqgis_developer_cookbook>
-   Documentation Guidelines (how to write the docs)<http://docs.qgis.org/2.0/en/docs/documentation_guidelines>
-   A gentle introduction in GIS <http://docs.qgis.org/2.0/en/docs/gentle_gis_introduction/>
-   PDF versions for printing <http://docs.qgis.org/2.0/pdf>
-   Trainings manual <http://docs.qgis.org/2.0/en/docs/training_manual/>
-
-
-Documentation for QGIS 1.8
---------------------------
-
-We keep a copy of the documentation of QGIS 1.8 around here: http://docs.qgis.org/1.8
-
-.. toctree::
-   :maxdepth: 1
-
-   User guide/Manual <http://docs.qgis.org/1.8/en/docs/user_manual>
-   PyQGIS cookbook <http://docs.qgis.org/1.8/en/docs/pyqgis_developer_cookbook>
-   Documentation Guidelines (how to write the docs)<http://docs.qgis.org/1.8/en/docs/documentation_guidelines>
-   A gentle introduction in GIS <http://docs.qgis.org/1.8/en/docs/gentle_gis_introduction/>
-   PDF versions for printing <http://docs.qgis.org/1.8/pdf>
-
-
-Documentation for QGIS testing
-------------------------------
-
-Although not translated we also build the documentation for the release QGIS which
-is currently developed. We call this version 'QGIS testing' and documentation 
-can be found here: http://docs.qgis.org/testing
-
-.. toctree::
-   :maxdepth: 1
-
-   User guide/Manual <http://docs.qgis.org/testing/en/docs/user_manual>
-   PyQGIS cookbook <http://docs.qgis.org/testing/en/docs/pyqgis_developer_cookbook>
-   Documentation Guidelines (how to write the docs)<http://docs.qgis.org/testing/en/docs/documentation_guidelines>
-   A gentle introduction in GIS <http://docs.qgis.org/testing/en/docs/gentle_gis_introduction/>
-   PDF versions for printing <http://docs.qgis.org/testing/pdf>
-   Trainings manual <http://docs.qgis.org/testing/en/docs/training_manual/>
-
-
 


### PR DESCRIPTION
I think this is a little clearer, I see this pattern used in other pages (e.g. https://github.com/qgis/QGIS-Website/blob/master/source/site/index.rst)
