### PR TITLE
remove toplevel "root" link in TOC.

### DIFF
--- a/themes/qgis-theme/myglobaltoc.html
+++ b/themes/qgis-theme/myglobaltoc.html
@@ -1,11 +1,1 @@
-{#
-    basic/globaltoc.html
-    ~~~~~~~~~~~~~~~~~~~~
-
-    Sphinx sidebar template: global table of contents.
-
-    :copyright: Copyright 2007-2013 by the Sphinx team, see AUTHORS.
-    :license: BSD, see LICENSE for details.
-#}
-<h3><a href="{{ pathto(master_doc) }}">{{ _('Table Of Contents') }}</a></h3>
 {{ toctree() }}

--- a/themes/qgis-theme/static/qgis-style.css
+++ b/themes/qgis-theme/static/qgis-style.css
@@ -601,10 +601,8 @@ section.content h4 {
   -moz-box-shadow: none;
   box-shadow: none;
 }
-.bs-sidenav h3 {
-  text-transform: uppercase;
-  font-weight: normal;
-  font-size: 16px;
+.bs-sidenav > ul {
+  padding-top: 60px;
 }
 @media (min-width: 980px) {
   .navbar .container {

--- a/themes/qgis-theme/static/qgis-style.css
+++ b/themes/qgis-theme/static/qgis-style.css
@@ -601,9 +601,6 @@ section.content h4 {
   -moz-box-shadow: none;
   box-shadow: none;
 }
-.bs-sidenav > ul {
-  padding-top: 60px;
-}
 @media (min-width: 980px) {
   .navbar .container {
     width: 100% !important;
@@ -612,10 +609,16 @@ section.content h4 {
     width: 300px !important;
     margin: 0 !important;
   }
+  .bs-sidenav > ul {
+    padding-top: 60px;
+  }
 }
 @media (max-width: 980px) {
   body {
     padding-top: 0 !important;
+  }
+  .bs-sidenav.well {
+    border-right: none;
   }
 }
 #core-contributors a.reference.internal,

--- a/themes/qgis-theme/static/qgis-style.less
+++ b/themes/qgis-theme/static/qgis-style.less
@@ -604,9 +604,6 @@ section.content h4 {
   -moz-box-shadow: none;
   box-shadow: none;
 }
-.bs-sidenav > ul {
-  padding-top: 60px;
-}
 
 @media (min-width: 980px) {
   .navbar .container {
@@ -616,10 +613,16 @@ section.content h4 {
     width: 300px !important;
     margin: 0 !important;
   }
+  .bs-sidenav > ul {
+    padding-top: 60px;
+  }
 }
 @media (max-width: 980px) {
   body {
     padding-top: 0 !important;
+  }
+  .bs-sidenav.well {
+    border-right: none;
   }
 }
 #core-contributors a.reference.internal,

--- a/themes/qgis-theme/static/qgis-style.less
+++ b/themes/qgis-theme/static/qgis-style.less
@@ -604,11 +604,10 @@ section.content h4 {
   -moz-box-shadow: none;
   box-shadow: none;
 }
-.bs-sidenav h3 {
-  text-transform: uppercase;
-  font-weight: normal;
-  font-size: 16px;
+.bs-sidenav > ul {
+  padding-top: 60px;
 }
+
 @media (min-width: 980px) {
   .navbar .container {
     width: 100% !important;


### PR DESCRIPTION
People know what navigation is, we don't have to label it. Plus there's
a link to root at the top left. This just removes a bit of clutter.

Desktop Before vs. After

<img width="1093" alt="screen shot 2015-11-24 at 4 14 56 pm" src="https://cloud.githubusercontent.com/assets/217057/11384714/04270c6e-92c7-11e5-8471-62b5db0b83ab.png">

<img width="1099" alt="screen shot 2015-11-24 at 4 14 36 pm" src="https://cloud.githubusercontent.com/assets/217057/11384713/0422e9b8-92c7-11e5-9f59-af800063fcdc.png">

Mobile Before vs. After

<img width="200" alt="screen shot 2015-11-24 at 4 31 05 pm" src="https://cloud.githubusercontent.com/assets/217057/11384922/f2627250-92c8-11e5-95e7-271eae55d04a.png">
<img width="200" alt="screen shot 2015-11-24 at 4 31 47 pm" src="https://cloud.githubusercontent.com/assets/217057/11384923/f267fbd0-92c8-11e5-89e4-8247e60a3c10.png">
