### PR TITLE
Add informations about  doc and website writing and translation

### DIFF
--- a/source/site/getinvolved/development/bugreporting.rst
+++ b/source/site/getinvolved/development/bugreporting.rst
@@ -4,24 +4,35 @@
 Bugs, Features and Issues
 =========================
 
-If you find a bug, please report it!
+QGIS is a largely volunteer driven project, and is the work of a dedicated
+team of developers, documenters, translators and supporters.
+Despite the efforts of the team to release QGIS without bugs, there may remain
+some bugs. If you find a bug or want new features to be added, please report it!
 
-You need an OSGeo account and login in order to submit bug reports. To get
-started, first create `Create an OSGeo4 account
+Two main means are offered to report bugs, request enhancements and submit patches 
+either for the QGIS applications (through Redmine) or for the web site and 
+the documentation (through Github).
+
+Applications
+------------
+
+You need an OSGeo account and login in order to submit bug reports on QGIS 
+applications (QGIS Desktop, QGIS Browser and QGIS Server). 
+To get started, first `Create an OSGeo account
 <https://www.osgeo.org/cgi-bin/ldap_create_user.py>`_.
 
 Once you have your account, use `QGIS issue tracking
-<http://hub.qgis.org/projects/quantum-gis/issues>`_ to search if the issue
-you'd like to report is probably already entered.
+<http://hub.qgis.org/projects/quantum-gis/issues>`_ to check if the issue
+you'd like to report is not already entered.
 
-.. note:: On the `OSGEO userid page <http://www.osgeo.org/osgeo_userid>`_ you can
- find more information about the OSGEO id we use. For example to 
+.. note:: On the `OSGeo userid page <http://www.osgeo.org/osgeo_userid>`_ you can
+ find more information about the OSGeo id we use. For example to 
  `change your password <https://www.osgeo.org/cgi-bin/auth/ldap_edit_user.py>`_
  or email address. Lost your password? Then request a password reset
  via info at osgeo.org
 
 Issues
-------
+......
 
 Issues are used to report bugs, request enhancements and submit patches. 
 Redmine is more than a bug reporting system. Issues can be associated 
@@ -31,10 +42,10 @@ completing other tasks related to a release such as documentation,
 web site updates, packaging, and announcements.
 
 Filing an Issue
----------------
+...............
 
 Before reporting a bug
-......................
+^^^^^^^^^^^^^^^^^^^^^^
 
 Before filing a bug, review the currently open issues to make sure that 
 you aren't creating a duplicate. If you have additional information on an issue, 
@@ -44,17 +55,21 @@ still reproducible without them.
 Please don't report multiple unrelated bugs in a single bug report.
 
 Plugin bugs
-...........
+^^^^^^^^^^^
 
 Plugin bugs must be opened in their respective bug tracking system. 
 Check first if the plugin is listed in the 
 `plugin overview <http://hub.qgis.org/projects/qgis-user-plugins/>`_.
-If so, click on the plugin name then click "New issue". Otherwise, 
-consult the plugin documentation to find the address of the 
-relevant bug tracking system or a developer to contact.
+If so, click on the plugin name then click "New issue". 
+
+Most of the plugins are published in the official `QGIS Plugins repository 
+<http://plugins.qgis.org/plugins/>`_. If the plugin is available, you'll find 
+in its presentation a link to its bug tracker. Otherwise, consult the plugin 
+documentation to find the address of the relevant bug tracking system 
+or a developer to contact.
 
 Steps
-.....
+^^^^^
 
 To report a bug choose New Issue from the menu bar. Note: You can also request 
 an enhancement or submit a patch using the Ticket system.
@@ -68,7 +83,7 @@ Important information needed when opening a ticket:
   to repeat it; if you think the bug could be related to a certain platform 
   version or dependencies package version (GDAL, OGR, GEOS etc) include that 
   as well. If your QGIS crashes if might be useful to include a backtrace 
-  (see below).  A very important thing when reporting a bug is to boil down 
+  (see below). A very important thing when reporting a bug is to boil down 
   a minimum example that is needed to reproduce the bug. 
   The chances of a bug being addressed in a timely manner is directly related 
   to the speed with which the developer can reproduce the bug. If you make 
@@ -80,8 +95,10 @@ Important information needed when opening a ticket:
   High (a bug which has a major effect on the usability of a package), 
   or Blocker (a bug that makes QGIS totally unusable, causes serious 
   data loss or a regression from a previous QGIS version)
-* **Component** - Choose the aspect of the application that is most closely associated with the problem
-* **Milestone** - If this issue affects a particular Milestone in the project choose it from the drop-down list
+* **Component** - Choose the aspect of the application that is most closely
+  associated with the problem
+* **Milestone** - If this issue affects a particular Milestone in the project
+  choose it from the drop-down list
 * **Version** - Version of QGIS this issue affects
 * **Platform** - Choose the platform you are using
 
@@ -90,20 +107,20 @@ on "Preview". Please avoid editing existing reports, if not for typos.
 Better add further comments in any other case.
 
 Creating a backtrace
---------------------
+....................
 
 If you have a crash it might be useful to include a backtrace as the bug might
 be not reproducible on an other machine.
 
 On Linux QGIS automatically tries to use ``gdb`` to connect to the crashing
-process to produce a backtrace.   But some distributions disable the possiblity
-to connect debuggers to a running processes.  In that case ``gdb`` only
+process to produce a backtrace. But some distributions disable the possiblity
+to connect debuggers to a running processes. In that case ``gdb`` only
 produces a rather useless message like::
 
- QGIS died on signal 11Could not attach to process.  
+ QGIS died on signal 11Could not attach to process. 
  If your uid matches the uid of the target process, 
  check the setting of /proc/sys/kernel/yama/ptrace_scope, or try
- again as the root user.  
+ again as the root user. 
  For more details, see /etc/sysctl.d/10-ptrace.conf
  ptrace: Operation not permitted.
  No thread selected
@@ -114,32 +131,79 @@ produces a rather useless message like::
 In that case you should reenable that option by setting
 ``kernel.yama.ptrace_scope`` to 0 in ``/etc/sysctl.d/10-ptrace.conf`` (or
 ``/etc/sysctl.conf`` or some other file in ``/etc/sysctl.d/``) and 
-run ``sysctl -p`` as root.  When you reproduce the crash after that, 
+run ``sysctl -p`` as root. When you reproduce the crash after that, 
 a backtrace will be printed instead.
 
 If you cannot reproduce the crash, there should still be a core dump in the
 current directory, that can be analysed after the process has already
-terminated.  It's called ``core`` (on some systems a dot and the process id is
+terminated. It's called ``core`` (on some systems a dot and the process id is
 append to the filename).
 
-On some distributions the creation of core dumps is also disabled.  In the
+On some distributions the creation of core dumps is also disabled. In the
 event that you just get ``Aborted`` instead of ``Aborted (core dumped)`` when the 
 crash occurs. Then you need to run ``ulimit -c unlimited`` before starting QGIS. 
 You can also include that in your ``.profile``, so that it's always enabled when
 you login.
 
-To produce a backtrace from the core file it you start ``gdb
-/path/to/the/qgis/binary core``.  The binary is usually ``/usr/bin/qgis`` or
-``/usr/bin/qgis.bin`` on Debian with the GRASS plugin installed.  In ``gdb``
+To produce a backtrace from the core file, start ``gdb
+/path/to/the/qgis/binary core``. The binary is usually ``/usr/bin/qgis`` or
+``/usr/bin/qgis.bin`` on Debian with the GRASS plugin installed. In ``gdb``
 you run ``bt`` which will produce the backtrace.
 
 Log output on Windows
----------------------
+.....................
 
 The nightly build in OSGeo4W_ (package qgis-dev) is built with debugging
-output, that you can view with DebugView_.  If the problem is not easy to
+output, that you can view with DebugView_. If the problem is not easy to
 reproduce the output might shed some light about where QGIS crashes.
+
 
 .. _OSGeo4W: http://trac.osgeo.org/osgeo4w
 .. _DebugView: http://technet.microsoft.com/en-us/sysinternals/bb896647.aspx
 
+
+Website and Documentation
+-------------------------
+
+QGIS project provides an active `web site <http://qgis.org>`_ and a rich 
+`documentation <http://qgis.org/en/docs/index.html>`_. Despite our efforts,
+if you find an out of date information, a wrong or unclear statement 
+or miss a valuable information, please feel free to report it.
+
+The main sources of these documents are hosted and managed in GitHub repositories
+so in order to report bugs or submit patches, you need a GitHub account and login.
+
+Reporting an Issue
+..................
+
+To get started, first `Create a GitHub account <https://github.com/join>`_.
+
+Then, choose the appropriate repository :
+
+* https://github.com/qgis/QGIS-Documentation/issues for QGIS documentation
+* https://github.com/qgis/QGIS-Website/issues for the web site
+
+Check if the issue you'd like to report is not already entered.
+
+Click **New Issue**, type a title and a clear description for your issue.
+
+When you're finished, click **Submit new issue**.
+
+Submitting a Patch
+..................
+
+In addition to issue report, you can help to fix them. Fixing issues is done 
+in GitHub through pull requests. You need to `fork the repository 
+<https://help.github.com/articles/working-with-forks/>`_ you want to 
+contribute to and submit pull requests.
+
+You can find a few guidelines that will help you to easily get your patches  
+and pull requests into QGIS projects at :ref:`submit_patch`. And more widely, 
+You may need to read :ref:`git_access`. 
+
+.. note:: 
+  A ``Fix me`` link is provided at the bottom of any page of the web site
+  to help you directly improve this page and submit pull request.
+  
+  This option is also available in the footer of the Testing documentation.
+  

--- a/source/site/getinvolved/development/qgisdevelopersguide/git.rst
+++ b/source/site/getinvolved/development/qgisdevelopersguide/git.rst
@@ -1,3 +1,4 @@
+.. _git_access:
 
 GIT Access
 ===========
@@ -105,6 +106,18 @@ If you're interested in checking out QGIS documentation sources:
 You can also take a look at the readme included with the documentation repo for more information.
 
 
+QGIS website sources
+--------------------------
+
+If you're interested in checking out QGIS website sources:
+
+.. code-block:: bash
+
+  git clone git@github.com:qgis/QGIS-Website.git
+
+You can also take a look at the readme included with the website repo for more information.
+
+
 GIT Documentation
 -----------------
 
@@ -183,6 +196,7 @@ When you are finished with the new feature and happy with the stability, make
 an announcement on the developer list. Before merging back, the changes will
 be tested by developers and users.
 
+.. _submit_patch:
 
 Submitting Patches and Pull Requests
 ------------------------------------

--- a/source/site/getinvolved/document.rst
+++ b/source/site/getinvolved/document.rst
@@ -48,7 +48,7 @@ All the documentation sources are hosted in `QGIS-Documentation Github repositor
 <https://github.com/qgis/QGIS-Documentation>`_. If you want to update some features
 in QGIS or document new ones, you need to:
 
-- have a `Github account <https://www.osgeo.org/cgi-bin/ldap_create_user.py>`_
+- have a `GitHub account <https://github.com/join>`_
 - `fork the repository <https://help.github.com/articles/working-with-forks/>`_
 - do your changes : guidelines for writing QGIS documentation are available at
   http://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html

--- a/source/site/getinvolved/document.rst
+++ b/source/site/getinvolved/document.rst
@@ -4,11 +4,11 @@ Write Documentation
 ===================
 
 The update of the QGIS documentation is managed by the :ref:`Community Team Lead <gui-translation>`.
-Have a look at the :ref:`QGIS Governance <gui-translation>` to find out who is in charge 
+Have a look at the :ref:`QGIS Governance <gui-translation>` to find out who is in charge
 of guiding you.
 
-The complete list of documents managed by the QGIS documentation team can be found 
-at http://www.qgis.org/en/docs/index.html. A list of documenters can be found at 
+The complete list of documents managed by the QGIS documentation team can be found
+at http://www.qgis.org/en/docs/index.html. A list of documenters can be found at
 https://github.com/qgis/QGIS-Documentation/graphs/contributors.
 
 .. _mailinglist-translation-docs:
@@ -17,14 +17,14 @@ Documentation Mailing list
 --------------------------
 
 If you plan to contribute to QGIS documentation, see :ref:`becoming-documenter`.
-For other related questions, please contact the :ref:`Documentation Team Leader 
-<community-resources>` or subscribe with the `qgis-community-team 
+For other related questions, please contact the :ref:`Documentation Team Leader
+<community-resources>` or subscribe with the `qgis-community-team
 <http://lists.osgeo.org/mailman/listinfo/qgis-community-team>`_ mailing list.
 
 After subscribing to the mailing list you are able to send a mail directly to
 qgis-community-team@lists.osgeo.org asking for help.
 
-We strongly encourage anyone dealing with documentation and its translations to 
+We strongly encourage anyone dealing with documentation and its translations to
 join this list and promise that it is usually a very low traffic mailing list.
 
 The other available mailing lists can be found at :ref:`QGIS-mailinglists`.
@@ -35,26 +35,29 @@ Becoming a documenter
 ---------------------
 
 The QGIS project is always looking for people who are willing to invest some
-more time updating QGIS documentation and translating it into a foreign language 
+more time updating QGIS documentation and translating it into a foreign language
 - even perhaps to coordinate the update and translation effort.
 
 We are trying to improve our project management process and spread the load
 more evenly between people who each have a specific area of responsibility,
 so any contribution you have to make will be greatly appreciated.
 
-The complete list of documents managed by the QGIS documentation team can be found 
+The complete list of documents managed by the QGIS Documentation Team can be found
 at http://www.qgis.org/en/docs/index.html.
 All the documentation sources are hosted in `QGIS-Documentation Github repository
 <https://github.com/qgis/QGIS-Documentation>`_. If you want to update some features
 in QGIS or document new ones, you need to:
 
-- have a Github account
-- fork the repository
-- do your changes and submit pull request
-  
-You can find a few guidelines that will help you manage these processes at :ref:`git_access`. 
+- have a `Github account <https://www.osgeo.org/cgi-bin/ldap_create_user.py>`_
+- `fork the repository <https://help.github.com/articles/working-with-forks/>`_
+- do your changes : guidelines for writing QGIS documentation are available at
+  http://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html
+- and submit a pull request. You can find a few guidelines that will help you manage
+  these processes at :ref:`git_access`.
 
 .. note:: 
-  A ``Fix me`` link provided at the bottom of any page of the Testing documentation
-  helps you directly update the page in your fork and submit pull request.
+  To help you easily find which file to update in the repository, there's a ``Fix me`` link
+  provided at the bottom of any page of the Testing documentation that
+  helps you directly reach the corresponding file in your fork.
+  Just make your changes and submit pull request.
 

--- a/source/site/getinvolved/document.rst
+++ b/source/site/getinvolved/document.rst
@@ -8,18 +8,18 @@ Have a look at the :ref:`QGIS Governance <gui-translation>` to find out who is i
 of guiding you.
 
 The complete list of documents managed by the QGIS documentation team can be found 
-at www.qgis.org/en/docs/index.html. A list of documenters can be found at 
+at http://www.qgis.org/en/docs/index.html. A list of documenters can be found at 
 https://github.com/qgis/QGIS-Documentation/graphs/contributors.
 
 .. _mailinglist-translation-docs:
 
 Documentation Mailing list
-...........................
+--------------------------
 
-If you plan to contribute to an existing document and for other related questions, 
-please contact the Documentation Team Leader (see :ref:`Organigram <gui-translation>`) or 
-subscribe with the `qgis-community-team <http://lists.osgeo.org/mailman/listinfo/qgis-community-team>`_
-mailing list.
+If you plan to contribute to QGIS documentation, see :ref:`becoming-documenter`.
+For other related questions, please contact the :ref:`Documentation Team Leader 
+<community-resources>` or subscribe with the `qgis-community-team 
+<http://lists.osgeo.org/mailman/listinfo/qgis-community-team>`_ mailing list.
 
 After subscribing to the mailing list you are able to send a mail directly to
 qgis-community-team@lists.osgeo.org asking for help.
@@ -29,8 +29,10 @@ join this list and promise that it is usually a very low traffic mailing list.
 
 The other available mailing lists can be found at :ref:`QGIS-mailinglists`.
 
+.. _becoming-documenter:
+
 Becoming a documenter
-.....................
+---------------------
 
 The QGIS project is always looking for people who are willing to invest some
 more time updating QGIS documentation and translating it into a foreign language 
@@ -40,14 +42,19 @@ We are trying to improve our project management process and spread the load
 more evenly between people who each have a specific area of responsibility,
 so any contribution you have to make will be greatly appreciated.
 
-If you would like to nominate yourself as a coordinator for a manual, a single 
-manual chapter or a language please go ahead. If more than one person 
-nominate themselves as coordinator for the same document, please contact each 
-other and resolve how you will manage your efforts.
+The complete list of documents managed by the QGIS documentation team can be found 
+at http://www.qgis.org/en/docs/index.html.
+All the documentation sources are hosted in `QGIS-Documentation Github repository
+<https://github.com/qgis/QGIS-Documentation>`_. If you want to update some features
+in QGIS or document new ones, you need to:
 
-Please :ref:`contact <community-resources>` the Community Assistant or the Doc
-translation team leader to see your name entered in the About Box of QGIS.
+- have a Github account
+- fork the repository
+- do your changes and submit pull request
+  
+You can find a few guidelines that will help you manage these processes at :ref:`git_access`. 
 
-
-
+.. note:: 
+  A ``Fix me`` link provided at the bottom of any page of the Testing documentation
+  helps you directly update the page in your fork and submit pull request.
 

--- a/source/site/getinvolved/mailinglists.rst
+++ b/source/site/getinvolved/mailinglists.rst
@@ -2,10 +2,11 @@
 
 .. _QGIS-mailinglists:
 
-Mailinglists
-============
+Mailing lists
+=============
 
-We communicate on mailing lists divided by topics and target groups. Feel free to subscribe to any of these lists.
+We communicate on mailing lists divided by topics and target groups. 
+Feel free to subscribe to any of these lists.
 
 
 QGIS users list
@@ -46,7 +47,7 @@ http://lists.osgeo.org/mailman/listinfo/qgis-community-team
 QGIS translation
 -----------------
 
-List for translators of either the website, or the QGIS itself
+List for translators of either the website, the documentation or the QGIS itself
 
 
 http://lists.osgeo.org/mailman/listinfo/qgis-tr

--- a/source/site/getinvolved/translate.rst
+++ b/source/site/getinvolved/translate.rst
@@ -3,36 +3,29 @@
 Translation
 ===========
 
-.. _translate-gui:
+QGIS is natively developed in English, either for the user interface (GUI) or
+for its documentation and web site. However, all these components are available 
+in many other languages since it is designed to be translated into any language 
+quite easily. 
+At this moment over fourthy other languages are already available 
+(though not all well maintained) for the GUI and more than twenty for web site 
+and documentation. 
+
+The translation process is managed by the :ref:`Translation Team <gui-translation>`
+and all the activities are done under the `Transifex <https://www.transifex.com/>`_ 
+platform.
 
 
-The translation of the user interface (GUI) is managed by the :ref:`Translation
-team lead <gui-translation>`.
-Have a look at the :ref:`QGIS Governance <gui-translation>` to find out who is
-in charge of guiding you.
-
-If you want to find out if your language is already present in QGIS or who is
-currently working on your language you have to take a look in the
-:menuselection:`Help -> About -> Translators` Box in the QGIS Desktop
-Application.
-
-You will also find the progress of the translation there (but remember in
-every "stable" version it will always stay at the same level).
-For finding the current percentage of translation you will either have to
-install the nightly build of QGIS or checkout the source code of QGIS and
-start translating there.
-
-.. _mailinglist-translation-gui:
+.. _mailinglist-translation:
 
 Translators Mailing list
-........................
+------------------------
 
 If you plan to contribute to an existing language or you want to translate
-the QGIS GUI into a not yet existing language and for any other related
-questions, please contact the Translation Team Leader
-(see :ref:`Organigram <gui-translation>`) or subscribe with the
-`qgis-gui-translation-team <http://lists.osgeo.org/mailman/listinfo/qgis-tr>`_
-mailing list.
+QGIS into a not yet existing language, see :ref:`becoming-translator`. 
+For any other related questions, please contact the  
+:ref:`Translation Team Leader <gui-translation>` or subscribe to the `QGIS 
+Translation mailing list <http://lists.osgeo.org/mailman/listinfo/qgis-tr>`_.
 
 After subscribing to the mailing list you are able to send a mail directly to
 qgis-tr@lists.osgeo.org asking for help.
@@ -40,10 +33,40 @@ qgis-tr@lists.osgeo.org asking for help.
 We strongly encourage anyone dealing with translations to join this list and
 promise that it is usually a very low traffic mailing list.
 
-The other available mailing list can be found at :ref:`QGIS-mailinglists`.
+The other available mailing lists can be found at :ref:`QGIS-mailinglists`.
+
+
+.. _translate-gui:
+
+GUI Translation
+---------------
+
+The QGIS interface is natively programmed in English. However, at this moment 
+over fourthy other languages are already available.
+
+To start QGIS with the appropriate localization, run qgis with the option
+``--lang=<language code>`` or change localization in QGIS under
+:menuselection:`Settings -> Options -> Locale`.
+
+If you want to find out if your language is already present in QGIS Applications
+or who is currently working on your language you have to take a look in the
+:menuselection:`Help -> About -> Translators` Box in the QGIS Desktop Application.
+
+You will also find the progress of the translation there (but remember in
+every "stable" version it will always stay at the same level).
+For finding the current percentage of translation you will either have to
+install the nightly build of QGIS or checkout the source code of QGIS.
+ 
+The entire interface contains over 
+ten thousand pieces of text and a complete translation will take days if not
+weeks to be finished. Besides that, the rapid development of the application
+continuously causes new and edited texts to be translated. A huge effort and
+your help will be appreciated!
+
+.. _becoming-translator:
 
 Becoming a translator
-.....................
+---------------------
 
 The QGIS project is always looking for people who are willing to invest some
 more time translating QGIS into a foreign language - even perhaps to
@@ -59,55 +82,31 @@ If more than one person nominate themselves as coordinator for the same
 language, please contact each other and resolve how you will manage your
 efforts.
 
-Please :ref:`contact <community-resources>` the Community Assistant or the GUI
-translation team leader to see you name entered in the About Box of QGIS.
-
-Helping with an existing translation
-....................................
-
-If you like to help translating QGIS into a your language please assign
-to the :ref:`translators mailing list <mailinglist-translation-gui>` and ask who
-is already working on that language to coordinate and collaborate.
-
-To start QGIS with the appropriate localization, run qgis with the option
---lang=<language code> or change localization in QGIS under
-:menuselection:`Settings -> Options -> Locale`.
-
-.. _howto-translate-gui:
-
-Documentation
--------------
-
-The QGIS interface is natively programmed in English. However, it is designed
-to be translated into any language quite easily. At this moment over fifty
-other languages are already available (though not all well maintained).
-
-All available languages are listed in the QGIS About dialog. It also shows
-how much of it has been translated yet. The entire interface contains over
-ten thousand pieces of text and a complete translation will take days if not
-weeks to be finished. Besides that, the rapid development of the application
-continuously causes new and edited texts to be translated. A huge effort and
-your help will be appreciated!
+Please contact the :ref:`Translation team leader <gui-translation>` or 
+:ref:`Community Assistant <community-resources>` to see your name entered in 
+the About Box of QGIS Desktop.
 
 Transifex
-^^^^^^^^^
+.........
 
 The web-based translating platform Transifex is used for all QGIS
 translations; the desktop application itself (or GUI), the documentation and
 the web site. So the first thing you need is an account to login and get
 started.
 
-Get an account
-^^^^^^^^^^^^^^
+Join a Project
+..............
 
-- Go to www.transifex.com and create a new account
+- Go to http://www.transifex.com and create a new account
 - Verify your account by the link in the email you will receive
 - Login
 - Choose your role as “Translator” and answer some other questions about yourself
-- At your dashboard page click “Join an existing organisation” and search for “qgis”
+- At your dashboard page click “Join an existing organisation” and search for “qgis”. 
+  Some QGIS organisations are listed now, among them are:
 
-Some QGIS organisations are listed now, among them are QGIS Desktop, Website and
-Documentation.
+  * **QGIS Desktop** for all the pieces of text available in QGIS apps 
+    (QGIS Desktop, QGIS Browser and QGIS Server),
+  * **QGIS Docs and Website** to translate both QGIS web site and current documentation.
 
 - Choose in which part of the project you would like to participate
 - You can be part of all projects and help everywhere too
@@ -116,13 +115,31 @@ Documentation.
   language. Keep in mind that translating the entire Desktop Application will take
   days of work, if not weeks!
 
-Now you will need to wait for the maintainers to process your request. You will be
-notified by email when your request has been accepted.
+Now you will need to wait for the language coordinator or the project maintainers 
+to process your request. You will be notified by email when your request has been 
+accepted. If your request has no answer for about a week, please consider writing 
+to your language coordinator in Transifex or the :ref:`QGIS Translators mailing list 
+<mailinglist-translation>`.
 
-Note on new languages
-^^^^^^^^^^^^^^^^^^^^^
 
-With requesting a new language please bear in mind that we try to make it as simple
-as possible. Just ask for the language you want to translate (regardless in which
-country you reside). Only if there are notable differences in the languages (for
-example portuguese in Portugal in Brazil) we will create its own version.
+.. note:: 
+  With requesting a new language please bear in mind that we try to make 
+  it as simple as possible. Just ask for the language you want to translate 
+  (regardless in which country you reside). Only if there are notable differences 
+  in the languages (for example portuguese in Portugal vs Brazil) we will create 
+  its own version.
+
+Translate
+...........
+
+Once your request is accepted, you are able to translate any text in the project(s) 
+you've chosen. Simply click on your language, select the chapter you want to 
+translate and click on Translate. Easy, right?
+
+Note that website and documentation projects also offer a more direct way to 
+add or fix translations. Indeed, While reading the current documentation or 
+navigating on the web site, if you find a wrong or missing translation, 
+you can directly fix it, using a ``Fix me`` link, available at the bottom of any page.
+This leads you directly to the right chapter in Transifex.
+  
+  


### PR DESCRIPTION
While reading [Write Documentation](http://qgis.org/en/site/getinvolved/document.html), [Translate](http://qgis.org/en/site/getinvolved/translate.html) and [Bugs, Features and Issues](http://qgis.org/en/site/getinvolved/development/bugreporting.html), it looks like these sections were more focused on contributing to QGIS application and there were some copy/paste not at their place.

This Pull Request :
- introduces few elements on contributing to doc and website repo:
  - issue report, enhancement request, pull request via GitHub
  - translation via Transifex 
- rewrites process of becoming a new contributor, since there's no real need to get in touch with team manager before being able to contribute
- removes redundant parts or links

Remaining issues:
- [Translate](http://qgis.org/en/site/getinvolved/translate.html) and the [Organigram](http://qgis.org/en/site/getinvolved/governance/governance.html) above do also refer to a GUI Translation team though translation team translates GUI, web site and documentation. May be worth fixing (see #307 for an opinion)
- [Write Documentation](http://qgis.org/en/site/getinvolved/document.html) refers to a **Documentation Team Leader** who doesn't appear in the QGIS Organigram but links to GUI Translation team. I think it should be the Community Team Leader. Am I right? It may be worth using consistent terms among those different links.

@dassau @rduivenvoorde @mach0 
