### PR TITLE
Missing letter "s" in link

### DIFF
--- a/source/site/forusers/visualchangelog214/index.rst
+++ b/source/site/forusers/visualchangelog214/index.rst
@@ -842,7 +842,7 @@ also be used in the DB manager.
 
 |image36|
 
-This feature was funded by `Boundless Spatial <boundlesgeo.com>`__
+This feature was funded by `Boundless Spatial <boundlessgeo.com>`__
 
 This feature was developed by Luigi Pirelli
 


### PR DESCRIPTION
line 845 This feature was funded by `Boundless Spatial <boundlesgeo.com>`__
              should be
              This feature was funded by `Boundless Spatial <boundlessgeo.com>`__

(extra s in Boundles)
