### PR TITLE
Link to translation guidelines

### DIFF
--- a/source/site/getinvolved/translate.rst
+++ b/source/site/getinvolved/translate.rst
@@ -136,6 +136,9 @@ Once your request is accepted, you are able to translate any text in the project
 you've chosen. Simply click on your language, select the chapter you want to 
 translate and click on Translate. Easy, right?
 
+You'll find instructions on how to do a good translation in the `QGIS Translation Guidelines
+<http://docs.qgis.org/testing/en/docs/documentation_guidelines/do_translations.html>`_.
+
 Note that website and documentation projects also offer a more direct way to 
 add or fix translations. Indeed, While reading the current documentation or 
 navigating on the web site, if you find a wrong or missing translation, 


### PR DESCRIPTION
For a better translation and avoid recent build errors, it might be worth informing translators on translation rules.
This PR add a link to Translation guidelines in Doc testing (instead of current translatable 2.8 doc). This is because of the [PR 886](https://github.com/qgis/QGIS-Documentation/pull/886) that should update the guidelines and better fits the current process (use of Transifex)
