### PR TITLE
fix code for cloning repo

### DIFF
--- a/source/site/getinvolved/development/qgisdevelopersguide/git.rst
+++ b/source/site/getinvolved/development/qgisdevelopersguide/git.rst
@@ -101,7 +101,7 @@ If you're interested in checking out QGIS documentation sources:
 
 .. code-block:: bash
 
-  git clone git@github.com:qgis/QGIS-Documentation.git
+  git clone git://github.com/qgis/QGIS-Documentation.git
 
 You can also take a look at the readme included with the documentation repo for more information.
 
@@ -113,7 +113,7 @@ If you're interested in checking out QGIS website sources:
 
 .. code-block:: bash
 
-  git clone git@github.com:qgis/QGIS-Website.git
+  git clone git://github.com/qgis/QGIS-Website.git
 
 You can also take a look at the readme included with the website repo for more information.
 


### PR DESCRIPTION
I couldn't clone the repo using the code. Got:

> The authenticity of host 'github.com (192.30.252.128)' can't be established.
> RSA key fingerprint is 16:27:ac:a5:76:28:2d:36:63:1b:56:4d:eb:df:a6:48.
> Are you sure you want to continue connecting (yes/no)? yes
> Warning: Permanently added 'github.com,192.30.252.128' (RSA) to the list of known hosts.
> Permission denied (publickey).
> fatal: Could not read from remote repository.

Using the code in the PR just copies the repo without problem.
