### PR TITLE
Fix grammar error

### DIFF
--- a/themes/qgis-theme/index.html
+++ b/themes/qgis-theme/index.html
@@ -159,7 +159,7 @@
                         <div class="box-content">
                             <div class="highlights-icon" id="get-started"></div>
                             <p>
-                                {{ _('Started using QGIS for your GIS tasks.') }}
+                                {{ _('Start using QGIS for your GIS tasks.') }}
                             </p>
                         </div>
                     </div>


### PR DESCRIPTION
Start using QGIS ... reads better than
Started using QGIS ...

The other two highlights start with:
Shape the future ...
Find training ...
