### PR TITLE
The fix me link is now also in 2.14 doc footer

### DIFF
--- a/source/site/getinvolved/development/bugreporting.rst
+++ b/source/site/getinvolved/development/bugreporting.rst
@@ -213,5 +213,5 @@ You may need to read :ref:`git_access`.
   A ``Fix me`` link is provided at the bottom of any page of the web site
   to help you directly improve this page and submit pull request.
   
-  This option is also available in the footer of the Testing documentation.
+  This option is also available in the footer of the documentation.
   


### PR DESCRIPTION
Testing doc is not the only one with `fix me` link at the bottom.
