### PR TITLE
Cleanup of bug reporting description

### DIFF
--- a/source/site/getinvolved/development/bugreporting.rst
+++ b/source/site/getinvolved/development/bugreporting.rst
@@ -3,34 +3,34 @@
 
 Bugs, Features and Issues
 =========================
+.. contents::
+   :local:
 
 QGIS is a largely volunteer driven project, and is the work of a dedicated
 team of developers, documenters, translators and supporters.
 Despite the efforts of the team to release QGIS without bugs, there may remain
 some bugs. If you find a bug or want new features to be added, please report it!
 
-Two different means are offered to report bugs, request enhancements and submit
-patches to the project:
+Each part of the QGIS Project has a dedicated place where issues (feature requests
+or bugs) can be reported, managed and discussed. You'll find issues related to:
 
-* `Redmine trac <http://hub.qgis.org/projects/quantum-gis>`_ for issues
-  related to QGIS applications
-* and GitHub for `the web site <https://github.com/qgis/QGIS-Website/issues>`_ 
-  and `the documentation <https://github.com/qgis/QGIS-Documentation/issues>`_
-  matters.
+* QGIS applications (QGIS Desktop, QGIS Browser or QGIS Server) at
+  http://hub.qgis.org/projects/quantum-gis/issues
+* the `web site <http://qgis.org>`_ at https://github.com/qgis/QGIS-Website/issues
+* and the `documentation <http://docs.qgis.org>`_ at
+  https://github.com/qgis/QGIS-Documentation/issues.
 
 For questions, please contact the :ref:`QGIS-mailinglists`.
 
-Reports on applications
------------------------
+Reporting issues on QGIS applications
+---------------------------------------
 
-You need an OSGeo account and login in order to submit bug reports on QGIS 
-applications (QGIS Desktop, QGIS Browser and QGIS Server). 
+QGIS applications (QGIS Desktop, QGIS Browser and QGIS Server) issues
+are available in `Redmine <http://hub.qgis.org/projects/quantum-gis/issues>`_.
+In order to submit or comment a report, you need an OSGeo account and login. 
 To get started, first `Create an OSGeo account
 <https://www.osgeo.org/cgi-bin/ldap_create_user.py>`_.
-
-Once you have your account, use `QGIS issue tracking
-<http://hub.qgis.org/projects/quantum-gis/issues>`_ to check if the issue
-you'd like to report is not already entered.
+It may require some time to have your account approved.
 
 .. note:: On the `OSGeo userid page <http://www.osgeo.org/osgeo_userid>`_ you can
  find more information about the OSGeo id we use. For example to 
@@ -38,53 +38,28 @@ you'd like to report is not already entered.
  or email address. Lost your password? Then request a password reset
  via info at osgeo.org
 
-Issues
-......
 
-Issues are used to report bugs, request enhancements and submit patches. 
-Redmine is more than a bug reporting system. Issues can be associated 
-with a QGIS Milestone, allowing you to see progress towards completion. 
-Completion of a Milestone not only requires closing bugs, but 
-completing other tasks related to a release such as documentation, 
-web site updates, packaging, and announcements.
+Before reporting an issue
+..........................
 
-Filing an Issue
-...............
-
-Before reporting a bug
-^^^^^^^^^^^^^^^^^^^^^^
-
-Before filing a bug, review the currently open issues to make sure that 
+Before filing an issue, review the currently open issues to make sure that 
 you aren't creating a duplicate. If you have additional information on an issue, 
 you can add it to the existing ticket. Third party plugins might also cause problems. 
 If you have installed any, you should also verify that the problem is 
 still reproducible without them.
 Please don't report multiple unrelated bugs in a single bug report.
 
-Plugin bugs
-^^^^^^^^^^^
 
-Plugin bugs must be opened in their respective bug tracking system. 
-Check first if the plugin is listed in the 
-`plugin overview <http://hub.qgis.org/projects/qgis-user-plugins/>`_.
-If so, click on the plugin name then click "New issue". 
+Steps to create a report
+.........................
 
-Most of the plugins are published in the official `QGIS Plugins repository 
-<http://plugins.qgis.org/plugins/>`_. If the plugin is available, you'll find 
-in its presentation a link to its bug tracker. Otherwise, consult the plugin 
-documentation to find the address of the relevant bug tracking system 
-or a developer to contact.
-
-Steps
-^^^^^
-
-To report a bug choose New Issue from the menu bar. Note: You can also request 
-an enhancement or submit a patch using the Ticket system.
+Once your account is validated and you are logged in, a ``New Issue`` tab
+is available in the menu bar. Select it .
 
 Important information needed when opening a ticket:
 
 * **Tracker** - choose the ticket type from the drop-down list: Bug, Feature 
-  (new feature request) or Bounty (ticket for which a bounty has been defined)
+  (new feature request)
 * **Subject** - a short description of the issue
 * **Description** - Provide a full description of the problem including steps 
   to repeat it; if you think the bug could be related to a certain platform 
@@ -110,15 +85,15 @@ Important information needed when opening a ticket:
 * **Version** - Version of QGIS this issue affects
 * **Platform** - Choose the platform you are using
 
-Before sending the bug, please check the formatting of your report by clicking 
+Before sending the report, please check the formatting of your report by clicking 
 on "Preview". Please avoid editing existing reports, if not for typos. 
 Better add further comments in any other case.
 
 Creating a backtrace
-....................
+^^^^^^^^^^^^^^^^^^^^^^
 
 If you have a crash it might be useful to include a backtrace as the bug might
-be not reproducible on an other machine.
+be not reproducible on another machine.
 
 On Linux QGIS automatically tries to use ``gdb`` to connect to the crashing
 process to produce a backtrace. But some distributions disable the possiblity
@@ -159,7 +134,7 @@ To produce a backtrace from the core file, start ``gdb
 you run ``bt`` which will produce the backtrace.
 
 Log output on Windows
-.....................
+^^^^^^^^^^^^^^^^^^^^^^^
 
 The nightly build in OSGeo4W_ (package qgis-dev) is built with debugging
 output, that you can view with DebugView_. If the problem is not easy to
@@ -170,8 +145,22 @@ reproduce the output might shed some light about where QGIS crashes.
 .. _DebugView: http://technet.microsoft.com/en-us/sysinternals/bb896647.aspx
 
 
-Website and Documentation's reports
-------------------------------------
+Plugin bugs
+............
+
+Plugin bugs must be opened in their respective bug tracking system. 
+Check first if the plugin is listed in the 
+`plugin overview <http://hub.qgis.org/projects/qgis-user-plugins/>`_.
+If so, click on the plugin name then click "New issue". 
+
+Most of the plugins are published in the official `QGIS Plugins repository 
+<http://plugins.qgis.org/plugins/>`_. If the plugin is available, you'll find 
+in its presentation a link to its bug tracker. Otherwise, consult the plugin 
+documentation to find the address of the relevant bug tracking system 
+or a developer to contact.
+
+Reporting issues on QGIS web site or documentation
+---------------------------------------------------
 
 QGIS project provides an active `web site <http://qgis.org>`_ and a rich 
 `documentation <http://qgis.org/en/docs/index.html>`_. Despite our efforts,
@@ -181,12 +170,9 @@ or miss a valuable information, please feel free to report it.
 The main sources of these documents are hosted and managed in GitHub repositories
 so in order to report bugs or submit patches, you need a GitHub account and login.
 
-Reporting an Issue
-..................
-
 To get started, first `Create a GitHub account <https://github.com/join>`_.
 
-Then, choose the appropriate repository :
+Then, choose the appropriate repository:
 
 * https://github.com/qgis/QGIS-Documentation/issues for QGIS documentation
 * https://github.com/qgis/QGIS-Website/issues for the web site
@@ -197,21 +183,27 @@ Click **New Issue**, type a title and a clear description for your issue.
 
 When you're finished, click **Submit new issue**.
 
-Submitting a Patch
-..................
-
-In addition to issue report, you can help to fix them. Fixing issues is done 
-in GitHub through pull requests. You need to `fork the repository 
-<https://help.github.com/articles/working-with-forks/>`_ you want to 
-contribute to and submit pull requests.
-
-You can find a few guidelines that will help you to easily get your patches  
-and pull requests into QGIS projects at :ref:`submit_patch`. And more widely, 
-You may need to read :ref:`git_access`. 
-
 .. note:: 
   A ``Fix me`` link is provided at the bottom of any page of the web site
   to help you directly improve this page and submit pull request.
   
   This option is also available in the footer of the documentation.
+
+Submitting a Patch
+------------------
+
+In addition to issue report, you can help to fix issues. Fixing issues is done 
+in GitHub through pull requests. You need to `fork the repository 
+<https://help.github.com/articles/working-with-forks/>`_ you want to 
+contribute to and submit pull requests at:
+
+* https://github.com/qgis/QGIS for QGIS Desktop, Browser or Server applications
+* https://github.com/qgis/QGIS-Website for the web site at http://qgis.org
+* https://github.com/qgis/QGIS-Documentation for the documentation
+  available at http://docs.qgis.org
+
+You can find a few guidelines that will help you to easily get your patches  
+and pull requests into QGIS projects at :ref:`submit_patch`. And more widely, 
+You may need to read :ref:`git_access`. 
+
   

--- a/source/site/getinvolved/development/bugreporting.rst
+++ b/source/site/getinvolved/development/bugreporting.rst
@@ -3,8 +3,6 @@
 
 Bugs, Features and Issues
 =========================
-.. contents::
-   :local:
 
 QGIS is a largely volunteer driven project, and is the work of a dedicated
 team of developers, documenters, translators and supporters.


### PR DESCRIPTION
Try to make the description simpler and clearer and put more focus on reports on applications, hoping that people will less report applications issues in website or doc repositories
