### PR TITLE
ppa for ubuntugis in the debian/ubuntu install

### DIFF
--- a/source/site/forusers/alldownloads.rst
+++ b/source/site/forusers/alldownloads.rst
@@ -195,7 +195,8 @@ Example latest release for Debian jessie::
 If you use one of our ubuntugis based repositories you also need to add
 following line::
 
- deb     http://ppa.launchpad.net/ubuntugis/ubuntugis-unstable/ubuntu *codename* main
+ deb http://ppa.launchpad.net/ubuntugis/ppa/ubuntu *codename* main
+ deb-src http://ppa.launchpad.net/ubuntugis/ppa/ubuntu *codename* main 
 
 After that type::
 


### PR DESCRIPTION
I have been trying to install qgis following the debian/ubuntu instructions in linux mint rafaela 17.2 (trusty)  but I had broken packages errors. Following the ubuntugis page instructions the errors were fixed.
