### PR TITLE
Temp fix #389 until 2.18 changelog goes live

### DIFF
--- a/themes/qgis-theme/index.html
+++ b/themes/qgis-theme/index.html
@@ -34,7 +34,7 @@
                             <p class="caption-text">
                                 {{ _('Get it ...') }}
                                 <a class="caption-link" href="{{ pathto('site/forusers/download') }}" target="_blank">{{ _('download QGIS 2.18 Las Palmas')}}</a>
-                                {{ _('or read what is new in the:') }}<a class="caption-link" href="{{ pathto('site/forusers/visualchangelog218/index') }}">{{ _('Visual Changelog')}}</a>
+                                {{ _('or read what is new in the: Visual Changelog [Under Construction]') }}
 
                             </p>
                         </div>


### PR DESCRIPTION
The broken link to the visual changelog on the homepage has been reported here ( #389 ) and elsewhere (http://osgeo-org.1560.x6.nabble.com/Broken-Link-to-2-18-Visual-Change-Log-td5292394.html). While the long term fix is, of course, completing the changelog, for the time being this, or something like it seems clearer and less confusing from a user's perspective rather than sending them to a 404. The wording can be changed as seen fit. Once the changelog goes live, this change would then be rolled back and all would be well. Thanks for your consideration.
