### PR TITLE
update link for french CNRS tutorial

### DIFF
--- a/source/site/forusers/trainingmaterial/index.rst
+++ b/source/site/forusers/trainingmaterial/index.rst
@@ -39,7 +39,7 @@ Other resources from them are available here:
 http://www.geoinformations.developpement-durable.gouv.fr/qgis-r625.html
 
 The french National Center for Scientific Research (CNRS), created an online QGIS tutorial:
-http://www.ades.cnrs.fr/tutoqgis/index.php
+http://www.passages.cnrs.fr/tutoqgis/
 
 
 German


### PR DESCRIPTION
The link for the CNRS QGIS tutorial is dead, I replaced it with the new link.