### PR TITLE
Adding 2.18 doc pages

### DIFF
--- a/themes/qgis-theme/docs_index.html
+++ b/themes/qgis-theme/docs_index.html
@@ -85,10 +85,28 @@
         </div>
         <hr/>
 
+        <div class="row-fluid" id="218">
+            <div class="offset1 span5">
+                <h3>{{ _('QGIS 2.18') }}</h3>
+                <p>{{ _("We are still updating (not translating yet) the documentation for QGIS 2.18. This version can be found here: ") }} <a href="http://docs.qgis.org/2.18" target="_blank" class="reference external">{{ _('http://docs.qgis.org/2.18') }}</a></p>
+                <p><a href="http://docs.qgis.org/2.18/en/docs/user_manual" target="_blank" class="reference external">{{ _('User guide/Manual') }}</a></p>
+                <p><a href="http://docs.qgis.org/2.18/en/docs/training_manual/" >{{ _('QGIS Training manual') }}</a></p>
+                <p><a href="http://docs.qgis.org/2.18/en/docs/pyqgis_developer_cookbook" target="_blank" class="reference external">{{ _('PyQGIS Cookbook') }}</a></p>
+                <p><a href="http://docs.qgis.org/2.18/en/docs/developers_guide" target="_blank" class="reference external">{{ _('QGIS Developer''s Guide') }}</a></p>
+                <p><a href="http://docs.qgis.org/2.18/en/docs/documentation_guidelines" target="_blank" class="reference external">{{ _('Documentation Guidelines (how to write the docs)') }}</a></p>
+                <p><a href="http://docs.qgis.org/2.18/en/docs/gentle_gis_introduction/" target="_blank" class="reference external">{{ _('A gentle introduction in GIS') }}</a></p>
+                <p>{{ _('PDF versions of all above, eg for printing are available here: ') }} <a href="http://docs.qgis.org/2.18/pdf" class="reference external" target="_blank">{{ _('http://docs.qgis.org/testing/pdf') }}</a></p>
+                <p><a href="http://qgis.org/api/2.18" target="_blank" class="reference external">{{ _('C++ Api documentation') }}</a></p>
+                <p><a href="http://qgis.org/api/2.18/classQgisInterface.html" target="_blank" class="reference external">{{ _('Python (iface) Api documentation') }}</a></p>
+            </div>
+            <div class="span1"></div>
+        </div>
+        <hr>
+
         <div class="row-fluid" id="testing">
             <div class="offset1 span5">
                 <h3>{{ _('QGIS testing') }}</h3>
-                <p>{{ _("We are still updating (not translating yet) the documentation for releases newer than QGIS 2.14. We call this version 'QGIS testing' and can be found here: ") }} <a href="http://docs.qgis.org/testing" target="_blank" class="reference external">{{ _('http://docs.qgis.org/testing') }}</a></p>
+                <p>{{ _("We are also writing the documentation of the under development QGIS 3 release. We call this version 'QGIS testing' and can be found here: ") }} <a href="http://docs.qgis.org/testing" target="_blank" class="reference external">{{ _('http://docs.qgis.org/testing') }}</a></p>
                 <p><a href="http://docs.qgis.org/testing/en/docs/user_manual" target="_blank" class="reference external">{{ _('User guide/Manual') }}</a></p>
                 <p><a href="http://docs.qgis.org/testing/en/docs/training_manual/" >{{ _('QGIS Training manual') }}</a></p>
                 <p><a href="http://docs.qgis.org/testing/en/docs/pyqgis_developer_cookbook" target="_blank" class="reference external">{{ _('PyQGIS Cookbook') }}</a></p>


### PR DESCRIPTION
To be able to:
* use the Fix Me link on online 2.18 doc, and not always land on master branch;
* and easily compare the two docs when needed.

@rduivenvoorde could you do the other magics behind the scene to make it available? Thanks 