### PR TITLE
Warning Ubuntu version compatibility with master

### DIFF
--- a/source/site/forusers/alldownloads.rst
+++ b/source/site/forusers/alldownloads.rst
@@ -168,6 +168,8 @@ Lines of packages:
 +-----------------------+--------------------------------+------------------------+------------------------------------------------+
 | Development Version   | 2.99.x master [4]_             | Nightly build for      | http://qgis.org/debian-nightly                 |
 |                       |                                | **Debian and Ubuntu**  |                                                |
+|                       |                                | **newer than Yakkety** |                                                |
+|                       |                                | **(16.10)**            |                                                |
 |                       |                                | [5]_                   |                                                |
 |                       |                                +------------------------+------------------------------------------------+
 |                       |                                | Nightly build with     | http://qgis.org/ubuntugis-nightly              |


### PR DESCRIPTION
Specify where to get master builds for Ubuntu 16.04.

The version currently offered by debian-nightly is from January 7. As people (hopefully) start testing QGIS 2.99 more, we don't want them to report issues against this version. Still it's quite likely that people use this because it's (IIRC the latest) LTR and people don't read footnotes ;)

In addition to this, I would propose to remove the package from the 16.04 repository, @jef-n what do you think?