### PR TITLE
Edits to the Training Materials page

### DIFF
--- a/source/site/forusers/trainingmaterial/index.rst
+++ b/source/site/forusers/trainingmaterial/index.rst
@@ -45,7 +45,7 @@ http://www.geoinformations.developpement-durable.gouv.fr/qgis-supports-pedagogiq
 Other resources from them are available here:
 http://www.geoinformations.developpement-durable.gouv.fr/qgis-r625.html
 
-The french National Center for Scientific Research (CNRS), created an online QGIS tutorial:
+The French National Center for Scientific Research (CNRS), created an online QGIS tutorial:
 http://ouvrir.passages.cnrs.fr/tutoqgis/
 
 

--- a/source/site/forusers/trainingmaterial/index.rst
+++ b/source/site/forusers/trainingmaterial/index.rst
@@ -28,6 +28,13 @@ http://docs.qgis.org/latest/en/docs/training_manual/index.html
 Tutorial material, originally developed as part of a workshop for the Ecology and Evolutionary Biology Program at Texas A&M University (produced and maintained by Mike Treglia):
 http://mltconsecol.github.io/QGIS-Tutorial/
 
+In-person training material, originally developed for the New York City Department of Transportation:
+
+Introduction to GIS Fundamentals: http://training.datapolitan.com/qgis-training/Introduction_to_GIS_Fundamentals
+
+Intermediate GIS with QGIS and PostGIS: http://training.datapolitan.com/qgis-training/Intermediate_GIS/
+
+Source code for training is available here: https://github.com/Datapolitan-Training/qgis-training
 
 French
 ......

--- a/source/site/forusers/trainingmaterial/index.rst
+++ b/source/site/forusers/trainingmaterial/index.rst
@@ -16,7 +16,7 @@ The general idea is to be able to (re)use material from each other.
 Educators are encouraged to use/mix/add material to the QGIS Training Manual.
 
 Please write to richard@qgis.org if you want to have something added here.
-Or you edit this page in github and do a pull request.
+Or you edit this page in github (https://github.com/qgis/QGIS-Website/blob/master/source/site/forusers/trainingmaterial/index.rst) and do a pull request.
 
 
 English


### PR DESCRIPTION
This PR includes three changes:
+ Addition of links to our online open source training material using QGIS 
+ Addition of link to the Github for the QGIS website (saving others the necessary Google search)
+ Capitalization of the `f` in `French`

I tested these by running the build in Docker and the pages rendered correctly.