### PR TITLE
Fix macOS version number

### DIFF
--- a/themes/qgis-theme/forusers_download.html
+++ b/themes/qgis-theme/forusers_download.html
@@ -147,7 +147,7 @@
                         <ul class="inline download-row">
                           <li><i class="icon-download-alt icon-large"></i></li>
                           <li class="qgis-download"></li>
-                          <li class="download-text">{{ _('QGIS OS X Installer Version %s')|format( version ) }}</li>
+                          <li class="download-text">{{ _('QGIS OS X Installer Version %s')|format( ltrversion ) }}</li>
                         </ul>
                       </a>
                     </div>


### PR DESCRIPTION
Because version 3.0 is shown twice.
What could also be nice is to fix the line breaks around the python 3.6 hyperlink (and resize subtitles?)
![image](https://user-images.githubusercontent.com/7983394/38803396-66061b92-416f-11e8-9642-7ddc5f9b85a4.png)
