### PR TITLE
Fixes link to SHA of Latest release nightlies Windows 64 bit build

### DIFF
--- a/source/site/forusers/alldownloads.rst
+++ b/source/site/forusers/alldownloads.rst
@@ -60,7 +60,7 @@ Steps are:
 
 .. [1] Latest release nightlies SHA:
    `32 bit <http://download.osgeo.org/osgeo4w/x86/release/qgis/qgis-rel-dev/LATEST.sha>`__,
-   `64 bit <http://download.osgeo.org/osgeo4w/x86_64/release/qgis/qgis-ltr-dev/LATEST.sha>`__
+   `64 bit <http://download.osgeo.org/osgeo4w/x86_64/release/qgis/qgis-rel-dev/LATEST.sha>`__
 .. [2]  Latest long-term release nightlies SHA:
    `32 bit <http://download.osgeo.org/osgeo4w/x86/release/qgis/qgis-ltr-dev/LATEST.sha>`__,
    `64 bit <http://download.osgeo.org/osgeo4w/x86_64/release/qgis/qgis-ltr-dev/LATEST.sha>`__


### PR DESCRIPTION
In note [1] of the Windows section, the link of Latest release nightlies SHA 64 bit wrongly points to http://download.osgeo.org/osgeo4w/x86_64/release/qgis/qgis-ltr-dev/LATEST.sha instead of http://download.osgeo.org/osgeo4w/x86_64/release/qgis/qgis-rel-dev/LATEST.sha.
This corrects the link.