### PR TITLE
Fix training materials hierarchies

### DIFF
--- a/source/site/forusers/trainingmaterial/index.rst
+++ b/source/site/forusers/trainingmaterial/index.rst
@@ -18,14 +18,6 @@ Educators are encouraged to use/mix/add material to the QGIS Training Manual.
 Please write to richard@qgis.org if you want to have something added here.
 Or you edit this page on `Github <https://github.com/qgis/QGIS-Website/blob/master/source/site/forusers/trainingmaterial/index.rst>`_ and do a pull request.
 
-
-Brazilian Portuguese
-....................
-
-Roberto Ilacqua wrote a manual for image classification in QGIS: `Manual do
-QGIS para Classificação Supervisionada de Áreas <https://malariaeliminationblog.files.wordpress.com/2017/11/manual-qgis.pdf>`_,
-full version, 200 p - 2017 or `Manual do QGIS para Classificação Supervisionada de Áreas (short version) <https://malariaeliminationblog.files.wordpress.com/2018/01/protocol_lulc_methods.pdf>`_, short version, 34 p - 2017.
-
 English
 .......
 
@@ -41,6 +33,13 @@ In-person training material, originally developed for the New York City Departme
 * `Intermediate GIS with QGIS and PostGIS <http://training.datapolitan.com/qgis-training/Intermediate_GIS/>`_
 * `Source code for training materials <https://github.com/Datapolitan-Training/qgis-training>`_
 
+Brazilian Portuguese
+....................
+
+Roberto Ilacqua wrote a manual for image classification in QGIS: `Manual do
+QGIS para Classificação Supervisionada de Áreas <https://malariaeliminationblog.files.wordpress.com/2017/11/manual-qgis.pdf>`_,
+full version, 200 p - 2017 or `Manual do QGIS para Classificação Supervisionada de Áreas (short version) <https://malariaeliminationblog.files.wordpress.com/2018/01/protocol_lulc_methods.pdf>`_, short version, 34 p - 2017.
+
 French
 ......
 
@@ -53,11 +52,8 @@ http://www.geoinformations.developpement-durable.gouv.fr/qgis-r625.html
 The French National Center for Scientific Research (CNRS), created an online QGIS tutorial:
 http://ouvrir.passages.cnrs.fr/tutoqgis/
 
-
 German
 ......
 
-
 HSR material:
 http://giswiki.hsr.ch/QGIS-Materialien
-

--- a/source/site/forusers/trainingmaterial/index.rst
+++ b/source/site/forusers/trainingmaterial/index.rst
@@ -19,8 +19,8 @@ Please write to richard@qgis.org if you want to have something added here.
 Or you edit this page on `Github <https://github.com/qgis/QGIS-Website/blob/master/source/site/forusers/trainingmaterial/index.rst>`_ and do a pull request.
 
 
-Brazil
-------
+Brazilian Portuguese
+....................
 
 Roberto Ilacqua wrote a manual for image classification in QGIS: `Manual do
 QGIS para Classificação Supervisionada de Áreas <https://malariaeliminationblog.files.wordpress.com/2017/11/manual-qgis.pdf>`_,


### PR DESCRIPTION
It looks weird the current menu being

* Brazil
    - English
    - French
    - German

I think it should instead be

- Brazilian Portuguese
- English
- French
- German

Assuming too that it was intended to leave the languages in alphabetical order. Otherwise maybe English first as it has the largest number of materials, I think.

Cheers