### PR TITLE
Fix language names

### DIFF
--- a/themes/qgis-theme/languageswitch.html
+++ b/themes/qgis-theme/languageswitch.html
@@ -7,7 +7,7 @@
   <option value="de" title="{{ _('German') }}">Deutsch</option>
   <option value="es" title="{{ _('Spanish') }}">Español</option>
   <option value="fa" title="{{ _('Persian') }}">فارسی</option>
-  <option value="fi" title="{{ _('Finnish') }}">Suomalainen</option>
+  <option value="fi" title="{{ _('Finnish') }}">Suomi</option>
   <option value="fr" title="{{ _('French') }}">Français</option>
   <option value="gl" title="{{ _('Galician') }}">Galego</option>
   <option value="id" title="{{ _('Indonesian') }}">Bahasa Indonesia</option>
@@ -16,13 +16,13 @@
   <option value="ja" title="{{ _('Japanese') }}">日本語</option>
   <option value="km_KH" title="{{ _('Khmer') }}">ភាសាខ្មែរ    </option>
   <option value="ko" title="{{ _('Korean') }}">한국어</option>
-  <option value="lt" title="{{ _('Lithuanian') }}">Lietuvos</option>
+  <option value="lt" title="{{ _('Lithuanian') }}">Lietuvių</option>
   <option value="nl" title="{{ _('Dutch') }}">Nederlands</option>
   <option value="pl" title="{{ _('Polish') }}">Polski</option>
   <option value="pt_BR" title="{{ _('Portuguesei (Brazil)') }}">Português (Brasil)</option>
   <option value="pt_PT" title="{{ _('Portuguese') }}">Português</option>
   <option value="ro" title="{{ _('Romanian') }}">Română</option>
-  <option value="tr" title="{{ _('Turkish') }}">Turkish</option>
+  <option value="tr" title="{{ _('Turkish') }}">Türkçe</option>
   <option value="ru" title="{{ _('Russian') }}">Русский</option>
   <option value="uk" title="{{ _('Ukrainian') }}">Українська</option>
   <option value="zh-Hans" title="{{ _('Chinese (Simplified)') }}">簡体中文</option>


### PR DESCRIPTION
Fix some wrong native language names:
- (Finnish) _Suomalainen_ ➟ **Suomi**.
_Suomalainen_ (adjective) means "relating to the Finnish language or Finland", but language name is **Suomi** (noun).
- (Lithuanian) _Lietuvos_ ➟ **Lietuvių**.
It's the same here, _Lietuvos_ (adjective) means "relating to the Lithuanian language or Lithuania", but language name is **Lietuvių** (noun).
- (Turkish) _Turkish_ ➟ **Türkçe**.
Use native name instead of an English one.

Links:
- [List of language names](https://en.wikipedia.org/wiki/List_of_language_names)