### PR TITLE
Avoid an "Uncaught TypeError: a.indexOf is not a function"

### DIFF
--- a/themes/qgis-theme/static/qgis-site.js
+++ b/themes/qgis-theme/static/qgis-site.js
@@ -67,7 +67,7 @@ $(document).ready(function(){
         .attr("border", 0);
     };
 
-    $(window).load(function () {
+    $(window).on('load', function () {
         /*
         * Scroll the window to avoid the topnav bar
         * https://github.com/twitter/bootstrap/issues/1768


### PR DESCRIPTION
Substitute a deprecated $(window).load(function(){...}); with $(window).on('load', function(){ ...});

```
jQuery.Deferred exception: a.indexOf is not a function TypeError: a.indexOf is not a function
    at r.fn.init.r.fn.load (https://www.qgis.org/it/_static/jquery.js:4:18717)
    at HTMLDocument.<anonymous> (https://www.qgis.org/it/_static/qgis-site.js:70:15)
    at j (https://www.qgis.org/it/_static/jquery.js:2:29568)
    at k (https://www.qgis.org/it/_static/jquery.js:2:29882) undefined

jquery.js:4 Uncaught TypeError: a.indexOf is not a function
    at r.fn.init.r.fn.load (jquery.js:4)
    at HTMLDocument.<anonymous> (qgis-site.js:70)
    at j (jquery.js:2)
    at k (jquery.js:2)
```