### PR TITLE
Add install instructions for Solus

### DIFF
--- a/source/site/forusers/alldownloads.rst
+++ b/source/site/forusers/alldownloads.rst
@@ -448,6 +448,14 @@ Install with :
 
 pacman -S qgis
 
+Solus
+---------
+
+Current version is avaliable through the Solus repository.
+
+Install with :
+
+sudo eopkg it qgis
 
 QGIS LTR
 ...........

--- a/source/site/forusers/alldownloads.rst
+++ b/source/site/forusers/alldownloads.rst
@@ -418,24 +418,6 @@ where <VERSION> is for example 'openSUSE_Tumbleweed'.
 
 All packages include GRASS and Python support.
 
-Mandriva
---------
-
-QGIS stable
-...........
-
-Current::
-
- urpmi qgis-python qgis-grass
-
-Slackware
----------
-
-QGIS stable
-...........
-
-Packages on http://qgis.gotslack.org
-
 ArchLinux
 ---------
 
@@ -447,15 +429,6 @@ Archlinux is available in official repository : https://www.archlinux.org/packag
 Install with :
 
 pacman -S qgis
-
-Solus
----------
-
-Current version is avaliable through the Solus repository.
-
-Install with :
-
-sudo eopkg it qgis
 
 QGIS LTR
 ...........
@@ -480,6 +453,33 @@ yaourt -S qgis-git
 
 For bugs and other behaviour, read comments here : https://aur.archlinux.org/packages/qgis-git
 
+Solus
+---------
+
+Current version is avaliable through the Solus repository.
+
+Install with :
+
+sudo eopkg it qgis
+
+
+Slackware
+---------
+
+QGIS stable
+...........
+
+Packages on http://qgis.gotslack.org
+
+Mandriva
+--------
+
+QGIS stable
+...........
+
+Current::
+
+ urpmi qgis-python qgis-grass
 
 Mac OS X / macOS
 ================

--- a/themes/qgis-theme/forusers_download.html
+++ b/themes/qgis-theme/forusers_download.html
@@ -164,14 +164,15 @@
                     <div class="accordion-inner">
                       <p>{{ _('For many flavors of GNU/Linux binary packages (rpm and deb) or software repositories (to add to your installation manager) are available. Please select your choice of distro below:') }}</p>
                       <ul>
+                      <li><a href="{{ pathto('site/forusers/alldownloads') }}#archlinux">{{ _('ArchLinux') }}</a></li>
                       <li><a href="{{ pathto('site/forusers/alldownloads') }}#debian-ubuntu">{{ _('Debian/Ubuntu') }}</a></li>
                       <li><a href="{{ pathto('site/forusers/alldownloads') }}#fedora">{{ _('Fedora') }}</a></li>
+		      <li><a href="{{ pathto('site/forusers/alldownloads') }}#flatpak">{{ _('Flatpak') }}</a></li>
+                      <li><a href="{{ pathto('site/forusers/alldownloads') }}#mandriva">{{ _('Mandriva') }}</a></li>
                       <li><a href="{{ pathto('site/forusers/alldownloads') }}#opensuse">{{ _('openSUSE') }}</a></li>
                       <li><a href="{{ pathto('site/forusers/alldownloads') }}#rhel-centos-scientific-linux">{{ _('RHEL, CentOS, Scientific Linux, ...') }}</a></li>
-                      <li><a href="{{ pathto('site/forusers/alldownloads') }}#mandriva">{{ _('Mandriva') }}</a></li>
                       <li><a href="{{ pathto('site/forusers/alldownloads') }}#slackware">{{ _('Slackware') }}</a></li>
-                      <li><a href="{{ pathto('site/forusers/alldownloads') }}#archlinux">{{ _('ArchLinux') }}</a></li>
-		      <li><a href="{{ pathto('site/forusers/alldownloads') }}#flatpak">{{ _('Flatpak') }}</a></li>
+		      <li><a href="{{ pathto('site/forusers/alldownloads') }}#solus>{{ _('Solus') }}</a></li>
                       </ul>
                       <p class="download-text"><a href="{{ pathto('site/forusers/alldownloads') }}#linux">{{ _('Linux Installation Instructions') }}</a></p>
                     </div>


### PR DESCRIPTION
The accomplishmentsof this PR: 
- Adds install section for Solus
- Orders distributions alphabetically in the single list
- Distros in the full installation document aren't alphabetically since it doesn't make sense there but Slackware and Mandriva are dropped down due to not being very popular. They are basically ordered after popularity which makes a lot more sense...