### PR TITLE
Update links to OSX installers to use new package

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -337,10 +337,10 @@ context = {
     'binary': binary,
     'ltrbinary': ltrbinary,
     'infeaturefreeze': infeaturefreeze,
-    'release_mac': '3.8.0',
-    'binary_mac': '1',
-    'ltrrelease_mac': '3.4.9',
-    'ltrbinary_mac': '1',
+    'release_mac': '3_8_0',
+    'binary_mac': '20190624_033017',
+    'ltrrelease_mac': '3_4_9',
+    'ltrbinary_mac': '20190624_013826',
     'stripeformurl': '/stripe/form'
 }
 

--- a/themes/qgis-theme/forusers_download.html
+++ b/themes/qgis-theme/forusers_download.html
@@ -130,10 +130,8 @@
                   </div>
                   <div id="mac" class="accordion-body collapse in">
                     <div class="accordion-inner">
-                      <p>{{ _('Mac Installer Packages for macOS El Capitan (10.11) and newer.') }}</p>
-                      <p>{{ _('Installation instructions are in the Read Me on the disk image. These packages use the ') }} 
-                        <a href="http://www.python.org/" class="reference external">python.org Python 3</a>, {{ _('version 3.6, the "macosx10.9" build - other distributions are not supported. Install Python before installing QGIS.') }}</p>
-                      <p>{{ _('Additional GDAL format plugins and PROJ grids are available at ') }} <a href="https://www.kyngchaos.com/frameworks/" class="reference external">kyngchaos.com</a>.</p>
+                      <h4>{{ _('Offical All-in-one, signed installers') }}</h4>
+                      <p>{{ _('Mac Installer Packages for macOS High Sierra (10.13) and newer.') }}</p>
                       <h6>{{ _('Latest release (richest on features):') }}</h6>
                       <a href="http://qgis.org/downloads/macos/qgis-pr-final-{{ release_mac|e }}-{{ binary_mac|e }}.dmg">
                         <ul class="inline download-row">
@@ -148,6 +146,18 @@
                           <li><i class="icon-download-alt icon-large"></i></li>
                           <li class="{{ "qgis{}-download".format( "2" if ltrrelease_mac.startswith("2.") else "" ) }}"></li>
                           <li class="download-text">{{ _('QGIS macOS Installer Version %s')|format( ltrrelease_mac ) }}</li>
+                        </ul>
+                      </a>
+                      <h4>{{ _('Alternative builds for older systems') }}</h4>
+
+                      <p>{{ _('Mac Installer Packages for macOS El Capitan (10.11) and newer.') }}</p>
+                      <p>{{ _('Installation instructions are in the Read Me on the disk image. These packages use the ') }} <a href="http://www.python.org/" class="reference external">python.org Python 3</a>, {{ _('version 3.6, the "macosx10.9" build - other distributions are not supported. Install Python before installing QGIS.') }}</p>
+                      <p>{{ _('Additional GDAL format plugins and PROJ grids are available at ') }} <a href="https://www.kyngchaos.com/frameworks/" class="reference external">kyngchaos.com</a>.</p>
+                      <a href="https://www.kyngchaos.com/software/qgis/">
+                        <ul class="inline download-row">
+                          <li><i class="icon-download-alt icon-large"></i></li>
+                          <li class="{{ "qgis-download" }}"></li>
+                          <li class="download-text">{{ _('macOS Installers') }}</li>
                         </ul>
                       </a>
                     </div>

--- a/themes/qgis-theme/forusers_download.html
+++ b/themes/qgis-theme/forusers_download.html
@@ -131,10 +131,11 @@
                   <div id="mac" class="accordion-body collapse in">
                     <div class="accordion-inner">
                       <p>{{ _('Mac Installer Packages for macOS El Capitan (10.11) and newer.') }}</p>
-                      <p>{{ _('Installation instructions are in the Read Me on the disk image. These packages use the ') }} <a href="http://www.python.org/" class="reference external">python.org Python 3</a>, {{ _('version 3.6, the "macosx10.9" build - other distributions are not supported. Install Python before installing QGIS.') }}</p>
+                      <p>{{ _('Installation instructions are in the Read Me on the disk image. These packages use the ') }} 
+                        <a href="http://www.python.org/" class="reference external">python.org Python 3</a>, {{ _('version 3.6, the "macosx10.9" build - other distributions are not supported. Install Python before installing QGIS.') }}</p>
                       <p>{{ _('Additional GDAL format plugins and PROJ grids are available at ') }} <a href="https://www.kyngchaos.com/frameworks/" class="reference external">kyngchaos.com</a>.</p>
                       <h6>{{ _('Latest release (richest on features):') }}</h6>
-                      <a href="https://qgis.org/downloads/macOS/QGIS-macOS-{{ release_mac|e }}-{{ binary_mac|e }}.dmg">
+                      <a href="http://qgis.org/downloads/macos/qgis-pr-final-{{ release_mac|e }}-{{ binary_mac|e }}.dmg">
                         <ul class="inline download-row">
                           <li><i class="icon-download-alt icon-large"></i></li>
                           <li class="{{ "qgis{}-download".format( "2" if release_mac.startswith("2.") else "" ) }}"></li>
@@ -142,7 +143,7 @@
                         </ul>
                       </a>
                       <h6>{{ _('Long term release (most stable):') }}</h6>
-                      <a href="https://qgis.org/downloads/macOS/QGIS-macOS-{{ ltrrelease_mac|e }}-{{ ltrbinary_mac|e }}.dmg">
+                      <a href="http://qgis.org/downloads/macos/qgis_ltr_final-{{ ltrrelease_mac|e }}-{{ ltrbinary_mac|e }}.dmg">
                         <ul class="inline download-row">
                           <li><i class="icon-download-alt icon-large"></i></li>
                           <li class="{{ "qgis{}-download".format( "2" if ltrrelease_mac.startswith("2.") else "" ) }}"></li>

--- a/themes/qgis-theme/forusers_download.html
+++ b/themes/qgis-theme/forusers_download.html
@@ -133,7 +133,7 @@
                       <h4>{{ _('Offical All-in-one, signed installers') }}</h4>
                       <p>{{ _('Mac Installer Packages for macOS High Sierra (10.13) and newer.') }}</p>
                       <h6>{{ _('Latest release (richest on features):') }}</h6>
-                      <a href="http://qgis.org/downloads/macos/qgis-pr-final-{{ release_mac|e }}-{{ binary_mac|e }}.dmg">
+                      <a href="https://qgis.org/downloads/macos/qgis-pr-final-{{ release_mac|e }}-{{ binary_mac|e }}.dmg">
                         <ul class="inline download-row">
                           <li><i class="icon-download-alt icon-large"></i></li>
                           <li class="{{ "qgis{}-download".format( "2" if release_mac.startswith("2.") else "" ) }}"></li>
@@ -141,7 +141,7 @@
                         </ul>
                       </a>
                       <h6>{{ _('Long term release (most stable):') }}</h6>
-                      <a href="http://qgis.org/downloads/macos/qgis_ltr_final-{{ ltrrelease_mac|e }}-{{ ltrbinary_mac|e }}.dmg">
+                      <a href="https://qgis.org/downloads/macos/qgis_ltr_final-{{ ltrrelease_mac|e }}-{{ ltrbinary_mac|e }}.dmg">
                         <ul class="inline download-row">
                           <li><i class="icon-download-alt icon-large"></i></li>
                           <li class="{{ "qgis{}-download".format( "2" if ltrrelease_mac.startswith("2.") else "" ) }}"></li>


### PR DESCRIPTION
WIP: Don't merge yet

This is just to get the party started. I need some reviews before we merge.  I also didn't remove any of the other text around the downloads as I wasn't sure what the process with the new installers is. 

I don't think we should wait to release these installers unless they are broken as I have heard they give a much better user experience.