### PR TITLE
Fix link to get involved in docs

### DIFF
--- a/themes/qgis-theme/docs_index.html
+++ b/themes/qgis-theme/docs_index.html
@@ -6,9 +6,9 @@
             <div class="offset1 span5">
                 <h2>{{ _('QGIS Documentation') }}</h2>
                 <p>{{ _('QGIS has a lot of documentation. All documentation is in English but some documents such as the user guide are also available in other languages.') }}</p>
-                <p>{{ _('You will find documentation for every QGIS release on the respective documentation website.') }}</p>
-                <p>{{ _('Get involved and help us to write a better documentation') }}
-                <a href="https://qgis.org/{{language}}/site/getinvolved/" target="_blank" >{{ _('Documentation Guidelines') }}</a></p>
+                <p>{{ _('You will find documentation for every QGIS long term release on the respective documentation website.') }}</p>
+                <p><a href="https://qgis.org/{{language}}/site/getinvolved/document.html" target="_blank" >{{ _('Get involved') }}</a> {{ _(' and help us write a better documentation.') }}
+                </p>
             </div>
             <div class="span1"></div>
             <div class="span4">


### PR DESCRIPTION
Fix #649
Instead of the image below with a url that leads to the [main get involved page](https://qgis.org/en/site/getinvolved/)
![image](https://user-images.githubusercontent.com/7983394/62583628-3f2ac300-b8b1-11e9-9abb-a47b5f4dc947.png)

this PR proposes the next image with a link on the Get involved text leading to [get involved in docs page](https://qgis.org/en/site/getinvolved/document.html)
![image](https://user-images.githubusercontent.com/7983394/62583677-78633300-b8b1-11e9-886a-7929d351d8b1.png)

Also fix information that only LTRs are documented.