### PR TITLE
Fixed typo on For Users > Download page

### DIFF
--- a/themes/qgis-theme/forusers_download.html
+++ b/themes/qgis-theme/forusers_download.html
@@ -130,7 +130,7 @@
                   </div>
                   <div id="mac" class="accordion-body collapse in">
                     <div class="accordion-inner">
-                      <h4>{{ _('Offical All-in-one, signed installers') }}</h4>
+                      <h4>{{ _('Official All-in-one, signed installers') }}</h4>
                       <p>{{ _('Mac Installer Packages for macOS High Sierra (10.13) and newer.') }}</p>
                       <h6>{{ _('Latest release (richest on features):') }}</h6>
                       <a href="https://qgis.org/downloads/macos/qgis-macos-pr.dmg">


### PR DESCRIPTION
Within the OS X section, I changed `Offical` to `Official`.