### PR TITLE
Fixes links to Documentation team leader and Governance

### DIFF
--- a/source/site/getinvolved/document.rst
+++ b/source/site/getinvolved/document.rst
@@ -3,8 +3,8 @@
 Write Documentation
 ===================
 
-The update of the QGIS documentation is managed by the :ref:`Community Team Lead <gui-translation>`.
-Have a look at the :ref:`QGIS Governance <gui-translation>` to find out who is in charge
+The update of the QGIS documentation is managed by the :ref:`Community Team Lead <community-resources>`.
+Have a look at the :ref:`QGIS Governance <whoiswho>` to find out who is in charge
 of guiding you.
 
 The complete list of documents managed by the QGIS documentation team can be found


### PR DESCRIPTION
Both links were pointing to the gui_translation. Fixes links to Documentation team leader and Governance.