### PR TITLE
Fix left margin on carousel caption links

### DIFF
--- a/themes/qgis-theme/index.html
+++ b/themes/qgis-theme/index.html
@@ -45,7 +45,7 @@
                         <div class="carousel-caption">
                             <h5 class="caption-headline">{{ _('22st Developer meeting') }}</h5>
                             <p class="caption-text">
-                               {{_('Come along to')}}<a class="caption-link" href="" target="_blank">{{_('A Coruña, Spain')}}</a>
+                               {{_('Come along to') }}<a class="caption-link" href="" target="_blank"> {{_('A Coruña, Spain')}} </a>
                                {{_('to find out more about QGIS!')}} 
                             </p>
                         </div>

--- a/themes/qgis-theme/static/qgis-style.css
+++ b/themes/qgis-theme/static/qgis-style.css
@@ -378,7 +378,6 @@ somebody comes up with a better idea */
   color: #ccc;
 }
 .carousel-caption .caption-link {
-  margin-left: 10px;
 }
 .carousel-caption .caption-link:hover {
   text-decoration: none;

--- a/themes/qgis-theme/static/qgis-style.less
+++ b/themes/qgis-theme/static/qgis-style.less
@@ -378,7 +378,6 @@ somebody comes up with a better idea */
   color: #ccc;
 }
 .carousel-caption .caption-link {
-  margin-left: 10px;
 }
 .carousel-caption .caption-link:hover {
   text-decoration: none;


### PR DESCRIPTION
The links in the captions of the home page banner have an unnecessary and unaesthetic 10 px left margin:
![image](https://user-images.githubusercontent.com/16253859/67263591-d8c54200-f4a8-11e9-968a-00418928add6.png)
![image](https://user-images.githubusercontent.com/16253859/67263531-b03d4800-f4a8-11e9-84e1-49f7f5195996.png)
![image](https://user-images.githubusercontent.com/16253859/67263546-bc290a00-f4a8-11e9-875e-4187d4c33a35.png)

This patch should fix it, removing the .carousel-caption .caption-link left margin in qgis-style.less and qgis-style.css