### PR TITLE
Fix line break in accordion blocks external links

### DIFF
--- a/themes/qgis-theme/forusers_download.html
+++ b/themes/qgis-theme/forusers_download.html
@@ -151,8 +151,8 @@
                       <h4>{{ _('Alternative build') }}</h4>
 
                       <p>{{ _('Mac Installer Packages for macOS El Capitan (10.11) and newer.') }}</p>
-                      <p>{{ _('Installation instructions are in the Read Me on the disk image. These packages use the ') }} <a href="http://www.python.org/" class="reference external">python.org Python 3</a>, {{ _('version 3.6, the "macosx10.9" build - other distributions are not supported. Install Python before installing QGIS.') }}</p>
-                      <p>{{ _('Additional GDAL format plugins and PROJ grids are available at ') }} <a href="https://www.kyngchaos.com/frameworks/" class="reference external">kyngchaos.com</a>.</p>
+                      <p>{{ _('Installation instructions are in the Read Me on the disk image. These packages use the ') }} <a href="http://www.python.org/" class="reference external" style="display:inline;margin-right:auto">python.org Python 3</a>, {{ _('version 3.6, the "macosx10.9" build - other distributions are not supported. Install Python before installing QGIS.') }}</p>
+                      <p>{{ _('Additional GDAL format plugins and PROJ grids are available at ') }} <a href="https://www.kyngchaos.com/frameworks/" class="reference external" style="display:inline;margin-right:auto">kyngchaos.com</a>.</p>
                       <a href="https://www.kyngchaos.com/software/qgis/">
                         <ul class="inline download-row">
                           <li><i class="icon-download-alt icon-large"></i></li>


### PR DESCRIPTION
It's just a patch to override the display and margin-right properties of "#downloads .accordion-inner a" style for external download links in "Download for macOS" accordion section.
Probably there are other elegant way to do it.

Now:
![image](https://user-images.githubusercontent.com/16253859/67309662-90d00a80-f4fc-11e9-82f0-55f1b74e3c47.png)

With the proposed patch:
![image](https://user-images.githubusercontent.com/16253859/67309606-7138e200-f4fc-11e9-95fe-8886d1b4be96.png)

Fixes #599