### PR TITLE
Fix two "and" conjunctions not translatable in download page

### DIFF
--- a/themes/qgis-theme/forusers_download.html
+++ b/themes/qgis-theme/forusers_download.html
@@ -230,7 +230,8 @@
           <div class="tab-pane" id="tab2">
               <p>{{ _('Previous releases of QGIS are still available') }} <a href="https://qgis.org/downloads">{{ _('here') }}</a> {{ _(' - including older releases for OS X ') }}
               <a href="https://qgis.org/downloads/macOS/">{{ _('here') }}</a>.</p>
-              <p>{{ _('More older releases are available') }} <a href="http://download.osgeo.org/qgis/" class="reference external">{{ _('here') }}</a> and
+              <p>{{ _('More older releases are available') }} <a href="http://download.osgeo.org/qgis/" class="reference external">{{ _('here') }}</a>
+              {{ _('and') }}
               {{ _('for OS X ') }} <a href="http://www.kyngchaos.com/software/archive/" class="reference external">{{ _('here') }}</a>.</p>
               <p>{{ _('Plugins for QGIS are also available ') }}<a href="http://plugins.qgis.org/plugins/" class="reference external">{{ _('here') }}</a>.</p>
           </div>
@@ -239,7 +240,8 @@
           <div class="tab-pane" id="tab3">
               <p>{{ _('QGIS is open source software available under the terms of the') }} <b>{{ _('GNU General Public License') }}</b> {{ _('meaning that its source code can be downloaded through tarballs or the git repository.') }}</p>
               <p>{{ _('QGIS Source Code is available ') }}
-                 <a href="https://qgis.org/downloads/qgis-latest.tar.bz2">{{ _('here (latest release)') }}</a> and
+                 <a href="https://qgis.org/downloads/qgis-latest.tar.bz2">{{ _('here (latest release)') }}</a>
+                 {{ _('and') }}
                  <a href="https://qgis.org/downloads/qgis-latest-ltr.tar.bz2">{{ _('here (long term release)') }}</a></p>
               <p>{{ _('Refer to the INSTALL guide on how to compile QGIS from source for the different platforms:') }} <a href="http://htmlpreview.github.io/?https://raw.github.com/qgis/QGIS/master/doc/INSTALL.html"  class="reference external">{{ _('here') }}</a></p>
               <p>{{ _('Note that you can also install the development version (nightly) via an installer from the normal downloads for your platform:') }} <a class="caption-link" href="{{ pathto('site/forusers/download') }}" target="_blank">{{ _('here')}}</a></p>


### PR DESCRIPTION
Fixes two "and" conjunctions that are not available for translation in the sentences: "More older releases are available here **and** for OS X here." and "QGIS Source Code is available here (latest release) **and** here (long term release)" in the [download](https://www.qgis.org/en/site/forusers/download.html) page,

Please, check if the fix actually fixes the bug before merging,