### PR TITLE
Point to development instructions page

### DIFF
--- a/themes/qgis-theme/getinvolved_index.html
+++ b/themes/qgis-theme/getinvolved_index.html
@@ -140,7 +140,7 @@
 		    <div class="span8">
                 <h3>{{ _('Develop a Plugin') }}</h3>
                 <p>{{ _('Want to write your own Python plugin? Go here: ') }} <a href="http://docs.qgis.org/testing/en/docs/pyqgis_developer_cookbook/" >{{ _('Developing Python plugins') }}</a>
-                <p>{{ _('Want to develop a C++ plugin? Go here: ') }} <a href="{{ pathto('site/getinvolved/development/plugindevelopment') }}#qgis-cpp-plugin-development" >{{ _('Developing CPP plugins') }}</a>.
+                <p>{{ _('Want to develop a C++ plugin? Go here: ') }} <a href="{{ pathto('site/getinvolved/development/development') }}#developing-c-plugin" >{{ _('Developing CPP plugins') }}</a>.
                 <p>{{ _('A wide range of great plugins exist for QGIS via the ') }} <a href="http://plugins.qgis.org" target="_blank">{{ _('QGIS Plugin web portal') }}</a>.
             </div>
         </div>
@@ -170,7 +170,7 @@
             <div class="span8">
                 <h3>{{ _('Sustain & Donate') }}</h3>
                 <p>{{ _('There are two kinds of financial contributions, we accept:') }}</p>
-                <p><strong>{{ _('Sustaining memberships:') }}</strong> {{ _(' annual commitments of funds to the project') }} - <a href="{{ pathto('site/getinvolved/governance/sustaining_members') }}">{{ _('more information and a list of our sustaining members') }}</a></p>
+                <p><strong>{{ _('Sustaining memberships:') }}</strong> {{ _(' annual commitments of funds to the project') }} - <a href="{{ pathto('site/getinvolved/governance/sustaining_members/index') }}">{{ _('more information and a list of our sustaining members') }}</a></p>
                 <p><strong>{{ _('donations:') }}</strong> {{ _(' one-time financial contributions to the project') }} - we accept <a href="{{ pathto('site/getinvolved/donations') }}">{{ _('donations via a variety of channels') }}</a></p>
             </div>
             

--- a/themes/qgis-theme/getinvolved_index.html
+++ b/themes/qgis-theme/getinvolved_index.html
@@ -150,7 +150,7 @@
                 <h3>{{ _('Develop QGIS Core') }}</h3>
                 <p>{{ _('QGIS Core consists on the one hand of the libraries enabling you to build custom tailored application by  providing a powerful API. On the other hand it consists of a desktop and server application which expose the possibilities offered by the libraries, offering a user friendly interface.') }}</p>
                 <h4 class="subsection-link">
-                    <a href="{{ pathto('site/getinvolved/development/qgisdevelopersguide/index') }}">{{ _('Get Set Up for QGIS Core Development') }}</a>
+                    <a href="{{ pathto('site/getinvolved/development/development') }}">{{ _('Get Set Up for QGIS Core Development') }}</a>
                 </h4>
                 <h4 class="subsection-link">
                     <a href="{{ pathto('site/getinvolved/development/roadmap') }}#release-schedule">{{ _('QGIS roadmap') }}</a>


### PR DESCRIPTION
developer's guide is no longer available in this repo. Meanwhile...
Fixes #712 , fixes #715, fixes #716 