### PR TITLE
remove direct link to QGIS for android.

### DIFF
--- a/source/site/forusers/alldownloads.rst
+++ b/source/site/forusers/alldownloads.rst
@@ -551,7 +551,7 @@ Flathub files: https://github.com/flathub/org.qgis.qgis
 Android
 =======
 
-There is an experimental version available on google play store.
+An old and deprecated not touch optimised release of QGIS for Android can be found on the google play store.
 
 https://play.google.com/store/apps/details?id=org.qgis.qgis
 

--- a/themes/qgis-theme/forusers_download.html
+++ b/themes/qgis-theme/forusers_download.html
@@ -230,11 +230,7 @@
                             <a class='app-download-button' href='https://github.com/roam-qgis/Roam/releases'><img alt='Get it on GitHub' src="{{pathto('_static/images/app_download_gh.png', 1)}}"/></a>
                         </div>
                         <h4 class="app-name">QGIS for Android</h4>
-                        <p>{{ _('An old and deprecated not touch optimised release of QGIS for Android can be found in the Play Store ') }}</p>
-                        <div class='app-download-buttons clearfix'>
-                            <a class='app-download-button' href='https://play.google.com/store/apps/details?id=org.qgis.qgis&utm_source=qgis.org'><img alt='Get it on Google Play' src="{{pathto('_static/images/app_download_play_store.png', 1)}}"/></a>
-                            <a class='app-download-button' href='https://github.com/qgis/QGIS-Android'><img alt='Get it on GitHub' src="{{pathto('_static/images/app_download_gh.png', 1)}}"/></a>
-                        </div>
+                        <p>{{ _('An old and deprecated not touch optimised release of QGIS for Android can be found in') }}<a href="{{ pathto('site/forusers/alldownloads') }}#android">{{ _('All downloads') }}</a></p>
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
As per PSC decision since this is which is deprecated
![image](https://user-images.githubusercontent.com/233663/77061820-281d8900-69db-11ea-89fd-24455b293afe.png)
