### PR TITLE
Fix index for testing documentation

### DIFF
--- a/themes/qgis-theme/docs_index.html
+++ b/themes/qgis-theme/docs_index.html
@@ -88,7 +88,7 @@
             <div class="span1"></div>
             <div class="offset1 span5">
                 <h3>{{ _('QGIS testing') }}</h3>
-                <p>{{ _("We are still updating (not translating yet) the documentation for releases newer than QGIS 3.4. We call this version 'QGIS testing' and can be found here: ") }} <a href="http://docs.qgis.org/testing" target="_blank" class="reference external">{{ _('http://docs.qgis.org/testing') }}</a></p>
+                <p>{{ _("We are still updating (not translating yet) the documentation for releases newer than QGIS 3.10. We call this version 'QGIS testing' and the documentation can be found here: ") }} <a href="http://docs.qgis.org/testing" target="_blank" class="reference external">{{ _('http://docs.qgis.org/testing') }}</a></p>
                 <p><a href="http://docs.qgis.org/testing/en/docs/user_manual" target="_blank" class="reference external">{{ _('User guide/Manual') }}</a></p>
                 <p><a href="http://docs.qgis.org/testing/en/docs/training_manual/" >{{ _('QGIS Training manual') }}</a></p>
                 <p><a href="http://docs.qgis.org/testing/en/docs/pyqgis_developer_cookbook" target="_blank" class="reference external">{{ _('PyQGIS Cookbook') }}</a></p>


### PR DESCRIPTION
QGIS testing now is "newer than QGIS ~~3.4~~ 3.10" and "We call this version 'QGIS testing' and _the documentation_ can be found here:"
