### PR TITLE
Make some strings localizable

### DIFF
--- a/themes/qgis-theme/docs_index.html
+++ b/themes/qgis-theme/docs_index.html
@@ -60,12 +60,12 @@
                         <li>{{ _('Learn GIS basics in') }} <a href="http://docs.qgis.org/3.10/{{language}}/docs/gentle_gis_introduction"  target="_blank">{{ _('A gentle introduction in GIS') }}</a></li>
                     </ul>
                 </p>
-                <p>For documentation writers:
+                <p>{{ _('For documentation writers:') }}
                     <ul>
                         <li>{{ _('Learn how to write docs using the') }} <a href="http://docs.qgis.org/3.10/{{language}}/docs/documentation_guidelines" target="_blank" >{{ _('Documentation Guidelines') }}</a></li>
                     </ul>
                 </p>
-                <p>For developers:
+                <p>{{ _('For developers:') }}
                     <ul>
                         <li>{{ _('Go Python, study the') }} <a href="http://docs.qgis.org/3.10/{{language}}/docs/pyqgis_developer_cookbook/"  target="_blank">{{ _('PyQGIS cookbook (for plugins and scripting)') }}</a></li>
                         <li> <a href="https://qgis.org/api/3.10/" target="_blank" class="reference external">{{ _('C++ Api documentation') }}</a></li>
@@ -114,12 +114,12 @@
                         <li>{{ _('Learn GIS basics in') }} <a href="http://docs.qgis.org/3.4/{{language}}/docs/gentle_gis_introduction"  target="_blank">{{ _('A gentle introduction in GIS') }}</a></li>
                     </ul>
                 </p>
-                <p>For documentation writers:
+                <p>{{ _('For documentation writers:') }}
                     <ul>
                         <li>{{ _('Learn how to write docs using the') }} <a href="http://docs.qgis.org/3.4/{{language}}/docs/documentation_guidelines" target="_blank" >{{ _('Documentation Guidelines') }}</a></li>
                     </ul>
                 </p>
-                <p>For developers:
+                <p>{{ _('For developers:') }}
                     <ul>
                         <li>{{ _('Go Python, study the') }} <a href="http://docs.qgis.org/3.4/{{language}}/docs/pyqgis_developer_cookbook/"  target="_blank">{{ _('PyQGIS cookbook (for plugins and scripting)') }}</a> (<a href="http://docs.qgis.org/3.4/pdf/{{language}}/QGIS-3.4-PyQGISDeveloperCookbook-{{language}}.pdf">{{ _('or as PDF') }}</a>) </li>
                         <li> <a href="https://qgis.org/api/3.4/" target="_blank" class="reference external">{{ _('C++ Api documentation') }}</a></li>


### PR DESCRIPTION
"For documentation writers:" and "For developers:" in docs_index.html