### PR TITLE
Update QGIS BugTracker link

### DIFF
--- a/source/site/getinvolved/faq/index.rst
+++ b/source/site/getinvolved/faq/index.rst
@@ -39,7 +39,7 @@ accurate can be the answer.
 
 .. note::
    In case of a broken function, you may give a look at `QGIS issue tracker
-   <https://issues.qgis.org/projects/qgis/issues>`_ before
+   <https://github.com/qgis/QGIS/issues>`_ before
    mailing to the list. More information at :ref:`QGIS-bugreporting`.
 
 


### PR DESCRIPTION
Replace the old Redmine bugtracker link https://issues.qgis.org/projects/qgis/issues with the new bugtracker link on GitHub https://github.com/qgis/QGIS/issues in the [GET INVOLVED / FAQ page](https://www.qgis.org/en/site/getinvolved/faq/index.html).

See also https://github.com/qgis/QGIS-Documentation/pull/5169