### PR TITLE
Update the developer meeting item in carousel

### DIFF
--- a/themes/qgis-theme/index.html
+++ b/themes/qgis-theme/index.html
@@ -44,10 +44,9 @@
                     <img src="{{pathto('_static/images/qgisorg_banner_devmeeting.png', 1)}}" alt="QGIS developer meeting">
                     <div class="container">
                         <div class="carousel-caption">
-                            <h5 class="caption-headline">{{ _('24th Developer meeting') }}</h5>
+                            <h5 class="caption-headline">{{ _('QGIS Community meetings') }}</h5>
                             <p class="caption-text">
-                               {{_('Come along to') }}<a class="caption-link" href="https://github.com/qgis/QGIS/wiki/24th-Contributor-Meeting-in-'s-Hertogenbosch" target="_blank"> {{_("'s-Hertogenbosch, The Netherlands")}} </a>
-                               {{_('to find out more about QGIS!')}} 
+                               {{_('Find out more about our tradition of user and contributor') }}<a class="caption-link" href=" http://blog.qgis.org/category/qgis-hackfest/" target="_blank"> {{_('meetings!')}}</a>
                             </p>
                         </div>
                     </div>


### PR DESCRIPTION
Supersedes #742

_Originally posted by @anitagraser in https://github.com/qgis/QGIS-Website/pull/742#issuecomment-632629263_
> Maybe we could put:
> QGIS Community meetings
> Find out more about our tradition of user and contributor meetings!
> (with a link to http://blog.qgis.org/category/qgis-hackfest/)