### PR TITLE
fix the spell error of chinese

### DIFF
--- a/themes/qgis-theme/languageswitch.html
+++ b/themes/qgis-theme/languageswitch.html
@@ -25,8 +25,8 @@
   <option value="tr" title="{{ _('Turkish') }}">Türkçe</option>
   <option value="ru" title="{{ _('Russian') }}">Русский</option>
   <option value="uk" title="{{ _('Ukrainian') }}">Українська</option>
-  <option value="zh-Hans" title="{{ _('Chinese (Simplified)') }}">簡体中文</option>
-  <option value="zh-Hant" title="{{ _('Chinese (Traditional)') }}">正體中文</option>
+  <option value="zh-Hans" title="{{ _('Chinese (Simplified)') }}">简体中文</option>
+  <option value="zh-Hant" title="{{ _('Chinese (Traditional)') }}">繁體中文</option>
 </select>
 
 <script>


### PR DESCRIPTION
The translate spell of Chinese (Simplified) and Chinese (Traditional) is not correct.

- `簡体中文` to `简体中文`
- `正體中文` to `繁體中文`