### PR TITLE
Fix Sample Dataset download link

### DIFF
--- a/themes/qgis-theme/forusers_download.html
+++ b/themes/qgis-theme/forusers_download.html
@@ -236,12 +236,12 @@
               </div>
               <!-- End Accordion -->
 
-              <h4><a href="{{ pathto('site/forusers/alldownloads') }}">{{ _('All downloads') }}</a></h4>
+              <h4>{{ _('All downloads') }}</h4>
               <p>
                 {{ _('More specific instructions about downloading QGIS stable vs QGIS development can be found in') }} <a href="{{ pathto('site/forusers/alldownloads') }}">{{ _('All downloads') }}</a>.
               </p>
 
-              <h4><a href="http://docs.qgis.org/latest/{{language}}/docs/user_manual/introduction/getting_started.html#downloading-sample-data">{{ _('Datasets') }}</a></h4>
+              <h4>{{ _('Datasets') }}</h4>
               <p>{{ _('For testing and learning purposes, a ') }} <a href="http://docs.qgis.org/latest/{{language}}/docs/user_manual/introduction/getting_started.html#downloading-sample-data"><strong>{{ _('sample dataset is available') }}</strong></a>, {{ _('which contains collections of data from different sources and in different formats.') }}</p>
 
           </div>

--- a/themes/qgis-theme/forusers_download.html
+++ b/themes/qgis-theme/forusers_download.html
@@ -241,8 +241,8 @@
                 {{ _('More specific instructions about downloading QGIS stable vs QGIS development can be found in') }} <a href="{{ pathto('site/forusers/alldownloads') }}">{{ _('All downloads') }}</a>.
               </p>
 
-              <h4><a href="http://docs.qgis.org/{{version}}/{{language}}/docs/user_manual/introduction/getting_started.html">{{ _('Datasets') }}</a></h4>
-              <p>{{ _('For testing and learning purposes, a ') }} <a href="http://docs.qgis.org/{{version}}/{{language}}/docs/user_manual/introduction/getting_started.html#sample-data"><strong>{{ _('sample dataset is available') }}</strong></a>, {{ _('which contains collections of data from different sources and in different formats.') }}</p>
+              <h4><a href="http://docs.qgis.org/latest/{{language}}/docs/user_manual/introduction/getting_started.html#downloading-sample-data">{{ _('Datasets') }}</a></h4>
+              <p>{{ _('For testing and learning purposes, a ') }} <a href="http://docs.qgis.org/latest/{{language}}/docs/user_manual/introduction/getting_started.html#downloading-sample-data"><strong>{{ _('sample dataset is available') }}</strong></a>, {{ _('which contains collections of data from different sources and in different formats.') }}</p>
 
           </div>
 


### PR DESCRIPTION
In the For Users / Download QGIS page at https://qgis.org/en/site/forusers/download.html, the link to download a sample dataset points to a nonexistent http://docs.qgis.org/3.12/en/docs/user_manual/introduction/getting_started.html#sample-data
as `http://docs.qgis.org/3.12/` is nonexistent and the "Downloading sample data" paragraph of the "Getting Started" chapter is at `/getting_started.html#downloading-sample-data`.

To fix this, I propose to change the link to `http://docs.qgis.org/latest/{{language}}/docs/user_manual/introduction/getting_started.html#downloading-sample-data`

