### PR TITLE
Update QGIS v3.14 release name to Pi

### DIFF
--- a/source/schedule.py
+++ b/source/schedule.py
@@ -3,7 +3,7 @@ from datetime import date
 # latest release
 version = '3.14'
 release = '3.14.0'
-codename = u'București'
+codename = u'Pi'
 binary = '1'
 releasedate = date(2020, 6, 19)
 releasenote = u'\u200B'


### PR DESCRIPTION
The previous release name is still appearing here: https://www.qgis.org/en/site/forusers/alldownloads.html
Using "Pi" instead of "π" because of this thread: https://github.com/qgis/QGIS/issues/37229

cc @jef-n 