### PR TITLE
Add specific item for server documentation

### DIFF
--- a/themes/qgis-theme/docs_index.html
+++ b/themes/qgis-theme/docs_index.html
@@ -89,7 +89,8 @@
             <div class="offset1 span5">
                 <h3>{{ _('QGIS testing') }}</h3>
                 <p>{{ _("We are still updating (not translating yet) the documentation for releases newer than QGIS 3.10. We call this version 'QGIS testing' and the documentation can be found here: ") }} <a href="https://docs.qgis.org/testing" target="_blank" class="reference external">{{ _('https://docs.qgis.org/testing') }}</a></p>
-                <p><a href="https://docs.qgis.org/testing/en/docs/user_manual" target="_blank" class="reference external">{{ _('User guide/Manual') }}</a></p>
+                <p><a href="https://docs.qgis.org/testing/en/docs/user_manual" target="_blank" class="reference external">{{ _('Desktop User guide/Manual') }}</a></p>
+		<p><a href="https://docs.qgis.org/testing/en/docs/server_manual" target="_blank" class="reference external">{{ _('Server guide/Manual') }}</a></p>
                 <p><a href="https://docs.qgis.org/testing/en/docs/training_manual/" >{{ _('QGIS Training manual') }}</a></p>
                 <p><a href="https://docs.qgis.org/testing/en/docs/pyqgis_developer_cookbook" target="_blank" class="reference external">{{ _('PyQGIS Cookbook') }}</a></p>
                 <p><a href="https://docs.qgis.org/testing/en/docs/developers_guide" target="_blank" class="reference external">{{ _('QGIS Developer''s Guide') }}</a></p>

--- a/themes/qgis-theme/docs_index.html
+++ b/themes/qgis-theme/docs_index.html
@@ -89,9 +89,9 @@
             <div class="offset1 span5">
                 <h3>{{ _('QGIS testing') }}</h3>
                 <p>{{ _("We are still updating (not translating yet) the documentation for releases newer than QGIS 3.10. We call this version 'QGIS testing' and the documentation can be found here: ") }} <a href="https://docs.qgis.org/testing" target="_blank" class="reference external">{{ _('https://docs.qgis.org/testing') }}</a></p>
-                <p><a href="https://docs.qgis.org/testing/en/docs/user_manual" target="_blank" class="reference external">{{ _('Desktop User guide/Manual') }}</a></p>
-		<p><a href="https://docs.qgis.org/testing/en/docs/server_manual" target="_blank" class="reference external">{{ _('Server guide/Manual') }}</a></p>
-                <p><a href="https://docs.qgis.org/testing/en/docs/training_manual/" >{{ _('QGIS Training manual') }}</a></p>
+                <p><a href="https://docs.qgis.org/testing/en/docs/user_manual" target="_blank" class="reference external">{{ _('Desktop User Guide/Manual') }}</a></p>
+		<p><a href="https://docs.qgis.org/testing/en/docs/server_manual" target="_blank" class="reference external">{{ _('Server Guide/Manual') }}</a></p>
+                <p><a href="https://docs.qgis.org/testing/en/docs/training_manual/" >{{ _('QGIS Training Manual') }}</a></p>
                 <p><a href="https://docs.qgis.org/testing/en/docs/pyqgis_developer_cookbook" target="_blank" class="reference external">{{ _('PyQGIS Cookbook') }}</a></p>
                 <p><a href="https://docs.qgis.org/testing/en/docs/developers_guide" target="_blank" class="reference external">{{ _('QGIS Developer''s Guide') }}</a></p>
                 <p><a href="https://github.com/qgis/QGIS/blob/master/INSTALL.md">Building QGIS from Source</a></p>


### PR DESCRIPTION
Since https://github.com/qgis/QGIS-Documentation/pull/5930 QGIS Server has now its own documentation chapter, separated from QGIS Desktop. 

This PR proposes to add a server item in the main website page to access directly to QGIS Server documentation.