### PR TITLE
Add note about xdg-desktop-portal for Flatpak

### DIFF
--- a/source/site/forusers/alldownloads.rst
+++ b/source/site/forusers/alldownloads.rst
@@ -537,6 +537,8 @@ To update your flatpak QGIS::
 
  flatpak update
 
+On certain distributions, you may also need to install xdg-desktop-portal or xdg-desktop-portal-gtk packages in order for file dialogs to appear.
+
 Flathub files: https://github.com/flathub/org.qgis.qgis and report issues here: https://github.com/flathub/org.qgis.qgis/issues
 
 Note: if you need to install additional Python modules, because they are needed by a plugin, you can install the module with (here installing the urllib3 module)::


### PR DESCRIPTION
This PR will add a note to the Flatpak-based installation instructions about the xdg-desktop-portal/xdg-desktop-portal-gtk packages. Users on certain distributions will need to install these packages in addition to Flatpak itself, or else file dialog boxes won't open. See previous discusson on flathub/org.qgis.qgis#32.