### PR TITLE
Remve EOL openSUSE 15.0 repo

### DIFF
--- a/source/site/forusers/alldownloads.rst
+++ b/source/site/forusers/alldownloads.rst
@@ -440,10 +440,6 @@ Leap 15.1::
 
  https://download.opensuse.org/repositories/Application:/Geo/openSUSE_Leap_15.1/
 
-Leap 15.0::
-
- https://download.opensuse.org/repositories/Application:/Geo/openSUSE_Leap_15.0/
-
 Factory ARM::
 
  https://download.opensuse.org/repositories/Application:/Geo/openSUSE_Factory_ARM/


### PR DESCRIPTION
@rduivenvoorde per your suggestion the EOL 15.0 repo removed. Thanks for the heads up.