### PR TITLE
Fix IRC logs archive URL

### DIFF
--- a/source/site/forusers/support.rst
+++ b/source/site/forusers/support.rst
@@ -39,7 +39,7 @@ A lot of the development buzz will be spoken on IRC.
 There is a #qgis channel on freenode.net.
 You can also use a web interface: http://webchat.freenode.net/?channels=#qgis
 If you missed a discussion on IRC, not a problem! We log all discussion, so you
-can easily catch up. Just go to https://qgis.org/irclogs.
+can easily catch up. Just go to http://irclogs.geoapt.com/qgis/.
 
 
 User Groups


### PR DESCRIPTION
Replaces https://qgis.org/irclogs with http://irclogs.geoapt.com/qgis/ in https://qgis.org/en/site/forusers/support.html

Fixes https://github.com/qgis/QGIS-Website/issues/830