### PR TITLE
Link to dedicated donations page

### DIFF
--- a/themes/qgis-theme/getinvolved_index.html
+++ b/themes/qgis-theme/getinvolved_index.html
@@ -54,7 +54,7 @@
                             <a href="#core">{{ _('Develop QGIS Core') }}</a>
                         </li>
                         <li>
-                            <a href="#donate">{{ _('Sponsor & Donate') }}</a>
+                            <a href="https://donate.qgis.org/">{{ _('Sponsor & Donate') }}</a>
                         </li>
                     </ul>
 -->


### PR DESCRIPTION
In an effort to remove cookies from the main website, we are moving the donations to its own subdomain (with cookie management crap included) at https://donate.qgis.org/