### PR TITLE
Update donate reference to use https://donate.qgis.org

### DIFF
--- a/themes/qgis-theme/index.html
+++ b/themes/qgis-theme/index.html
@@ -88,7 +88,7 @@
             <p class="muted">{{ _('Version') }} {{ release|e }} {{ releasenote|e }} <br/> {{ _('Version') }} {{ ltrrelease|e }} {{ ltrnote|e }}</p>
         </div>
         <div class="span5">
-            <p><a href="{{ pathto('site/getinvolved/donations') }}" class="btn btn-large btn-success btn-flat">{{ _('Support QGIS') }}</a></p>
+            <p><a href="https://donate.qgis.org/" class="btn btn-large btn-success btn-flat">{{ _('Support QGIS') }}</a></p>
             <p class="muted">{{ _('Donate now!') }}</p>
         </div>
     </div>


### PR DESCRIPTION
Related with #910 this changes the front page link to use a dedicated donations page