### PR TITLE
Remove Searchable Mailing Lists and Forum sections from Support page

### DIFF
--- a/source/site/forusers/support.rst
+++ b/source/site/forusers/support.rst
@@ -12,17 +12,6 @@ QGIS has a bunch of mailing lists. See :ref:`QGIS-mailinglists` for the differen
 If you are going to ask questions please read this: :ref:`how-to-ask-a-QGIS-question`.
 
 
-Searchable Mailing Lists
-------------------------
-
-Nabble (http://nabble.com) keeps a history of a lot of mailinglists.
-
-If you go to
-the osgeo section of it: http://osgeo-org.1560.x6.nabble.com/ you see there is a
-QGIS section also, where you can do a search over all QGIS lists, or refine it
-to e.g. only the users list.
-
-
 StackExchange
 -------------
 
@@ -90,13 +79,3 @@ Commercial Support
 ------------------
 
 You can also get support from companies near you, please visit this page: :ref:`QGIS-commercial_support`.
-
-
-Forums
-------
-
-QGIS does not have a forum. Please either search in StackExchange (see below),
-or via http://nabble.com in the history of our Mailinglists (see above).
-
-For non-english, note that there also exist local forums that have a dedicated
-section for QGIS you may need to search in.


### PR DESCRIPTION
The searchable mailing lists and forum services offered on nabble.com for OSGeo/QGIS are no longer available.
See: https://www.osgeo.org/foundation-news/osgeo-nabble-forum-is-shutting-down/
See also: https://github.com/qgis/QGIS-Website/commit/fab66204b295b7e16eeeff1d6255d33ed69569c0#r19270629

Page: https://qgis.org/en/site/forusers/support.html