### PR TITLE
add facebook community link

### DIFF
--- a/source/site/forusers/support.rst
+++ b/source/site/forusers/support.rst
@@ -20,8 +20,8 @@ tag ``qgis`` you'll see all QGIS related questions and answers:
 http://gis.stackexchange.com/?tags=qgis
 
 
-Chat
-----
+Communication channels
+----------------------
 
 Telegram
 ........
@@ -41,6 +41,10 @@ Matrix (https://matrix.org) is a project for decentralised chat. QGIS has a room
 To use Matrix: create an account (at matrix.org is easiest, but if you have an OSGeo account you can also use your OSGeo id as matrix id), install a client (Elements is easiest, but see https://matrix.org/docs/projects/try-matrix-now/#clients for more), OR point your browser to (https://matrix.to/#/!qgis:osgeo.org)
 
 To use IRC: install an IRC client and connect to irc://irc.libera.chat/#qgis or point your browser to https://web.libera.chat/?channels=#qgis
+
+Facebook
+........
+For Facebook users, an english-speaking global community group for QGIS users can be found at https://facebook.com/groups/612486875596534
 
 
 User Groups


### PR DESCRIPTION
As per PSC decision, adding the link to the FB group has over 50K members and is probably one of the biggest community group we have