### PR TITLE
Fix documentation for installing pip3 modules

### DIFF
--- a/source/site/forusers/alldownloads.rst
+++ b/source/site/forusers/alldownloads.rst
@@ -499,7 +499,7 @@ Flathub files: https://github.com/flathub/org.qgis.qgis and report issues here: 
 
 Note: if you need to install additional Python modules, because they are needed by a plugin, you can install the module with (here installing the urllib3 module)::
 
- flatpak run --command=pip3 org.qgis.qgis install urllib3 --user
+ flatpak run --devel --command=pip3 org.qgis.qgis install urllib3 --user
 
 
 Mac OS X / macOS


### PR DESCRIPTION
We need to pass --devel otherwise pip3 is not found.