### PR TITLE
Fix Linux links in Download page

### DIFF
--- a/themes/qgis-theme/forusers_download.html
+++ b/themes/qgis-theme/forusers_download.html
@@ -144,11 +144,10 @@
                       <ul>
                       <li><a href="{{ pathto('site/forusers/alldownloads') }}#debian-ubuntu">{{ _('Debian/Ubuntu') }}</a></li>
                       <li><a href="{{ pathto('site/forusers/alldownloads') }}#fedora">{{ _('Fedora') }}</a></li>
-                      <li><a href="{{ pathto('site/forusers/alldownloads') }}#opensuse">{{ _('openSUSE') }}</a></li>
-                      <li><a href="{{ pathto('site/forusers/alldownloads') }}#rhel-centos-scientific-linux">{{ _('RHEL, CentOS, Scientific Linux, ...') }}</a></li>
+                      <li><a href="{{ pathto('site/forusers/alldownloads') }}#suse-opensuse">{{ _('openSUSE') }}</a></li>
                       <li><a href="{{ pathto('site/forusers/alldownloads') }}#mandriva">{{ _('Mandriva') }}</a></li>
                       <li><a href="{{ pathto('site/forusers/alldownloads') }}#slackware">{{ _('Slackware') }}</a></li>
-                      <li><a href="{{ pathto('site/forusers/alldownloads') }}#archlinux">{{ _('Arch Linux') }}</a></li>
+                      <li><a href="{{ pathto('site/forusers/alldownloads') }}#arch-linux">{{ _('Arch Linux') }}</a></li>
                       <li><a href="{{ pathto('site/forusers/alldownloads') }}#flatpak">{{ _('Flatpak') }}</a></li>
                       </ul>
                       <p class="download-text"><a href="{{ pathto('site/forusers/alldownloads') }}#linux">{{ _('Linux Installation Instructions') }}</a></p>


### PR DESCRIPTION
Should the openSuse info be removed? See: https://github.com/qgis/QGIS-Website/issues/960