### PR TITLE
Follow new guidelines for 3rd party repositories on Ubuntu/Debian

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ source/static/
 venv
 #i18n
 .transifexrc
+.vscode

--- a/source/site/forusers/alldownloads.rst
+++ b/source/site/forusers/alldownloads.rst
@@ -116,8 +116,8 @@ First install some tools you will need for this instructions::
 Now install the QGIS Signing Key, so QGIS software from 
 the QGIS repo will be trusted and installed::
 
- sudo mkdir -p /etc/apt/keyrings && sudo chmod 755 /etc/apt/keyrings
- sudo wget -O/etc/apt/keyrings/qgis-archive-keyring.gpg https://download.qgis.org/downloads/qgis-archive-keyring.gpg
+ sudo mkdir -m755 -p /etc/apt/keyrings  # not needed since apt version 2.4.0 like Debian 12 and Ubuntu 22 or newer
+ sudo wget -O /etc/apt/keyrings/qgis-archive-keyring.gpg https://download.qgis.org/downloads/qgis-archive-keyring.gpg
 
 Add the QGIS repo for the latest stable QGIS (|version|.x |codename|) to ``/etc/apt/sources.list.d/qgis.sources``::
 
@@ -274,13 +274,13 @@ Should output::
 
 After you have verified the output you can install the key with::
 
-  sudo mkdir -p /etc/apt/keyrings && sudo chmod 755 /etc/apt/keyrings
+  sudo mkdir -m755 -p /etc/apt/keyrings  # not needed since apt version 2.4.0 like Debian 12 and Ubuntu 22 or newer
   sudo cp qgis-archive-keyring.gpg /etc/apt/keyrings/qgis-archive-keyring.gpg
 
 Alternatively you can download the key directly without manual verification::
         
-  sudo mkdir -p /etc/apt/keyrings && sudo chmod 755 /etc/apt/keyrings
-  sudo wget -O/etc/apt/keyrings/qgis-archive-keyring.gpg https://download.qgis.org/downloads/qgis-archive-keyring.gpg
+  sudo mkdir -m755 -p /etc/apt/keyrings  # not needed since apt version 2.4.0 like Debian 12 and Ubuntu 22 or newer
+  sudo wget -O /etc/apt/keyrings/qgis-archive-keyring.gpg https://download.qgis.org/downloads/qgis-archive-keyring.gpg
 
 With the keyring in place you can add the repository to as ``/etc/apt/sources.list.d/qgis.sources`` with following content::
 

--- a/source/site/forusers/alldownloads.rst
+++ b/source/site/forusers/alldownloads.rst
@@ -116,13 +116,13 @@ First install some tools you will need for this instructions::
 Now install the QGIS Signing Key, so QGIS software from 
 the QGIS repo will be trusted and installed::
 
- wget -O- https://qgis.org/downloads/qgis-2022.gpg.key | sudo gpg --dearmor --yes -o /usr/share/keyrings/qgis-archive.gpg
+ sudo wget -O/usr/share/keyrings/qgis-archive-keyring.gpg https://download.qgis.org/downloads/qgis-archive-keyring.gpg
 
 Add the QGIS repo for the latest stable QGIS (|version|.x |codename|).
 
 Note: "lsb_release -c -s" in those lines will return your distro name::
 
- echo "deb [signed-by=/usr/share/keyrings/qgis-archive.gpg] https://qgis.org/ubuntu $(lsb_release -c -s) main" | sudo tee /etc/apt/sources.list.d/qgis.list
+ echo "deb [signed-by=/usr/share/keyrings/qgis-archive-keyring.gpg] https://qgis.org/debian $(lsb_release -c -s) main" | sudo tee /etc/apt/sources.list.d/qgis.list
 
 Update your repository information to reflect also the just added QGIS one::
 
@@ -248,16 +248,36 @@ Supported distribution versions:
 |               | 20.04 (LTS)    | focal      | yes                   |
 +---------------+----------------+------------+-----------------------+
 
+To use the qgis archive you have to first add the archive's repository public key::
 
-Add the lines for one of the repositories to your ``/etc/apt/sources.list.d/qgis.list``::
+ wget https://download.qgis.org/downloads/qgis-archive-keyring.gpg
+ gpg --no-default-keyring --keyring ./qgis-archive-keyring.gpg --list-keys
+ 
+Should output::
 
- deb     *repository* *codename* main
- deb-src *repository* *codename* main
+ ./qgis-archive-keyring.gpg
+ --------------------------
+ pub   rsa4096 2022-08-08 [SCEA] [expires: 2027-08-08]
+       2D7E3441A707FDB3E7059441D155B8E6A419C5BE
+ uid           [ unknown] QGIS Archive Automatic Signing Key (2022-2027) <qgis-developer@lists.osgeo.org>
 
-Example latest release for Debian unstable::
+After you have verified the output you can install the key with::
 
- deb     https://qgis.org/debian unstable main
- deb-src https://qgis.org/debian unstable main
+  sudo cp qgis-archive-keyring.gpg /usr/share/keyrings/qgis-archive-keyring.gpg
+
+Alternatively you can download the key directly without manual verification::
+        
+ wget -O/usr/share/keyrings/qgis-archive-keyring.gpg https://download.qgis.org/downloads/qgis-archive-keyring.gpg
+
+With the keyring in place you can add the repository to as ``/etc/apt/sources.list.d/qgis.list`` with following content::
+
+ deb     [signed-by=/usr/share/keyrings/qgis-archive-keyring.gpg] *repository* *codename* main
+ deb-src [signed-by=/usr/share/keyrings/qgis-archive-keyring.gpg] *repository* *codename* main
+
+Example for the latest release for Debian unstable::
+
+ deb     [signed-by=/usr/share/keyrings/qgis-archive-keyring.gpg] https://qgis.org/debian unstable main
+ deb-src [signed-by=/usr/share/keyrings/qgis-archive-keyring.gpg] https://qgis.org/debian unstable main
 
 After that type the commands below to install QGIS::
 
@@ -273,25 +293,6 @@ In case you would like to install QGIS Server, type::
 
 .. note:: Please remove all the QGIS and GRASS packages you may have
    installed from other repositories before doing the update.
-
-In case of keyserver errors, download the qgis.org repository public key with::
-
- wget https://qgis.org/downloads/qgis-2022.gpg.key
- gpg --show-keys qgis-2022.gpg.key
-
-Should output::
-
- pub   rsa4096 2022-08-08 [SCEA] [expires: 2027-08-08]
-       2D7E 3441 A707 FDB3 E705  9441 D155 B8E6 A419 C5BE
- uid           [ unknown] QGIS Archive Automatic Signing Key (2022-2027) <qgis-developer@lists.osgeo.org>
-
-After you have verified the fingerprint you can install the key with::
-
- sudo gpg --yes -o /usr/share/keyrings/qgis-archive.gpg --dearmor qgis-2022.gpg.key
-
-Alternatively you can download the key from a keyserver without manual fingerprint verification::
-        
- wget -O- https://qgis.org/downloads/qgis-2022.gpg.key | sudo gpg --dearmor --yes -o /usr/share/keyrings/qgis-archive.gpg
 
 
 Fedora

--- a/source/site/forusers/alldownloads.rst
+++ b/source/site/forusers/alldownloads.rst
@@ -116,13 +116,23 @@ First install some tools you will need for this instructions::
 Now install the QGIS Signing Key, so QGIS software from 
 the QGIS repo will be trusted and installed::
 
- sudo wget -O/usr/share/keyrings/qgis-archive-keyring.gpg https://download.qgis.org/downloads/qgis-archive-keyring.gpg
+ sudo mkdir -p /etc/apt/keyrings && sudo chmod 755 /etc/apt/keyrings
+ sudo wget -O/etc/apt/keyrings/qgis-archive-keyring.gpg https://download.qgis.org/downloads/qgis-archive-keyring.gpg
 
-Add the QGIS repo for the latest stable QGIS (|version|.x |codename|).
+Add the QGIS repo for the latest stable QGIS (|version|.x |codename|) to ``/etc/apt/sources.list.d/qgis.sources``::
 
-Note: "lsb_release -c -s" in those lines will return your distro name::
+  Types: deb deb-src
+  URIs: https://qgis.org/debian
+  Suites: bullseye
+  Architectures: amd64
+  Components: main
+  Signed-By: /etc/apt/keyrings/qgis-archive-keyring.gpg
 
- echo "deb [signed-by=/usr/share/keyrings/qgis-archive-keyring.gpg] https://qgis.org/debian $(lsb_release -c -s) main" | sudo tee /etc/apt/sources.list.d/qgis.list
+.. note:: ``Suites`` in above lines depends on your distribution. ``lsb_release -cs`` will show your distribution name.
+
+   In some distributions (like Linux Mint), ``. /etc/os-release; echo "$UBUNTU_CODENAME"`` will show the correct distibution name.
+
+   See `Available codenames`_.
 
 Update your repository information to reflect also the just added QGIS one::
 
@@ -132,7 +142,7 @@ Now, install QGIS::
 
  sudo apt install qgis qgis-plugin-grass
 
-.. note:: Add 'qgis-server' to this line if you also want to install QGIS Server
+.. note:: Add ``qgis-server`` to this line if you also want to install QGIS Server
 
 
 Repositories
@@ -142,7 +152,7 @@ Default Debian and Ubuntu software repositories often hold older versions of
 QGIS.
 
 To have newer versions, you have to add alternative software repositories, by
-adding one of the deb-lines below to your /etc/apt/sources.list.d/qgis.list file.
+adding one of the deb-lines below to your /etc/apt/sources.list.d/qgis.sources file.
 
 Our main repository contains multiple lines of packages for several versions of
 **Debian and Ubuntu** based on the dependencies the individual distributions
@@ -229,6 +239,7 @@ Lines of packages:
 | Next release: |nextreleasedate|
 | (more dates see Release Schedule on :doc:`../getinvolved/development/roadmap`)
 
+.. _Available codenames:
 
 Supported distribution versions:
 
@@ -250,46 +261,56 @@ Supported distribution versions:
 
 To use the qgis archive you have to first add the archive's repository public key::
 
- wget https://download.qgis.org/downloads/qgis-archive-keyring.gpg
- gpg --no-default-keyring --keyring ./qgis-archive-keyring.gpg --list-keys
+  wget https://download.qgis.org/downloads/qgis-archive-keyring.gpg
+  gpg --no-default-keyring --keyring ./qgis-archive-keyring.gpg --list-keys
  
 Should output::
 
- ./qgis-archive-keyring.gpg
- --------------------------
- pub   rsa4096 2022-08-08 [SCEA] [expires: 2027-08-08]
-       2D7E3441A707FDB3E7059441D155B8E6A419C5BE
- uid           [ unknown] QGIS Archive Automatic Signing Key (2022-2027) <qgis-developer@lists.osgeo.org>
+  ./qgis-archive-keyring.gpg
+  --------------------------
+  pub   rsa4096 2022-08-08 [SCEA] [expires: 2027-08-08]
+        2D7E3441A707FDB3E7059441D155B8E6A419C5BE
+  uid           [ unknown] QGIS Archive Automatic Signing Key (2022-2027) <qgis-developer@lists.osgeo.org>
 
 After you have verified the output you can install the key with::
 
-  sudo cp qgis-archive-keyring.gpg /usr/share/keyrings/qgis-archive-keyring.gpg
+  sudo mkdir -p /etc/apt/keyrings && sudo chmod 755 /etc/apt/keyrings
+  sudo cp qgis-archive-keyring.gpg /etc/apt/keyrings/qgis-archive-keyring.gpg
 
 Alternatively you can download the key directly without manual verification::
         
- wget -O/usr/share/keyrings/qgis-archive-keyring.gpg https://download.qgis.org/downloads/qgis-archive-keyring.gpg
+  sudo mkdir -p /etc/apt/keyrings && sudo chmod 755 /etc/apt/keyrings
+  sudo wget -O/etc/apt/keyrings/qgis-archive-keyring.gpg https://download.qgis.org/downloads/qgis-archive-keyring.gpg
 
-With the keyring in place you can add the repository to as ``/etc/apt/sources.list.d/qgis.list`` with following content::
+With the keyring in place you can add the repository to as ``/etc/apt/sources.list.d/qgis.sources`` with following content::
 
- deb     [signed-by=/usr/share/keyrings/qgis-archive-keyring.gpg] *repository* *codename* main
- deb-src [signed-by=/usr/share/keyrings/qgis-archive-keyring.gpg] *repository* *codename* main
+  Types: deb deb-src
+  URIs: *repository*
+  Suites: *codename*
+  Architectures: amd64
+  Components: main
+  Signed-By: /etc/apt/keyrings/qgis-archive-keyring.gpg
 
-Example for the latest release for Debian unstable::
+Example for the latest long term release for Ubuntu 22.04 Jammy::
 
- deb     [signed-by=/usr/share/keyrings/qgis-archive-keyring.gpg] https://qgis.org/debian unstable main
- deb-src [signed-by=/usr/share/keyrings/qgis-archive-keyring.gpg] https://qgis.org/debian unstable main
+  Types: deb deb-src
+  URIs: https://qgis.org/ubuntu-ltr
+  Suites: jammy
+  Architectures: amd64
+  Components: main
+  Signed-By: /etc/apt/keyrings/qgis-archive-keyring.gpg
 
 After that type the commands below to install QGIS::
 
- sudo apt update
- sudo apt install qgis qgis-plugin-grass
+  sudo apt update
+  sudo apt install qgis qgis-plugin-grass
 
 In case you would like to install QGIS Server, type::
 
- sudo apt update
- sudo apt install qgis-server --no-install-recommends --no-install-suggests
- # if you want to install server Python plugins
- apt install python-qgis
+  sudo apt update
+  sudo apt install qgis-server --no-install-recommends --no-install-suggests
+  # if you want to install server Python plugins
+  apt install python-qgis
 
 .. note:: Please remove all the QGIS and GRASS packages you may have
    installed from other repositories before doing the update.

--- a/source/site/forusers/alldownloads.rst
+++ b/source/site/forusers/alldownloads.rst
@@ -116,14 +116,13 @@ First install some tools you will need for this instructions::
 Now install the QGIS Signing Key, so QGIS software from 
 the QGIS repo will be trusted and installed::
 
- wget -qO - https://qgis.org/downloads/qgis-2022.gpg.key | sudo gpg --no-default-keyring --keyring gnupg-ring:/etc/apt/trusted.gpg.d/qgis-archive.gpg --import
- sudo chmod a+r /etc/apt/trusted.gpg.d/qgis-archive.gpg
+ wget -O- https://qgis.org/downloads/qgis-2022.gpg.key | sudo gpg --dearmor --yes -o /usr/share/keyrings/qgis-archive.gpg
 
 Add the QGIS repo for the latest stable QGIS (|version|.x |codename|).
 
 Note: "lsb_release -c -s" in those lines will return your distro name::
 
- sudo add-apt-repository "deb https://qgis.org/ubuntu $(lsb_release -c -s) main"
+ echo "deb [signed-by=/usr/share/keyrings/qgis-archive.gpg] https://qgis.org/ubuntu $(lsb_release -c -s) main" | sudo tee /etc/apt/sources.list.d/qgis.list
 
 Update your repository information to reflect also the just added QGIS one::
 
@@ -143,7 +142,7 @@ Default Debian and Ubuntu software repositories often hold older versions of
 QGIS.
 
 To have newer versions, you have to add alternative software repositories, by
-adding one of the deb-lines below to your /etc/apt/sources.list file.
+adding one of the deb-lines below to your /etc/apt/sources.list.d/qgis.list file.
 
 Our main repository contains multiple lines of packages for several versions of
 **Debian and Ubuntu** based on the dependencies the individual distributions
@@ -153,7 +152,7 @@ For Ubuntu we also used to have extra packages in a separate repository that
 are based on `ubuntugis <https://launchpad.net/~ubuntugis>`_, which held more
 uptodate versions of other GIS packages than Ubuntu itself for LTS versions. If
 you want those you also need to include ubuntugis-unstable ppa in your
-/etc/apt/sources.list file (see `ubuntugis documentation
+/etc/apt/sources.list.d/qgis.list file (see `ubuntugis documentation
 <https://trac.osgeo.org/ubuntugis/wiki/UbuntuGISRepository>`_).
 
 
@@ -250,7 +249,7 @@ Supported distribution versions:
 +---------------+----------------+------------+-----------------------+
 
 
-Add the lines for one of the repositories to your ``/etc/apt/sources.list``::
+Add the lines for one of the repositories to your ``/etc/apt/sources.list.d/qgis.list``::
 
  deb     *repository* *codename* main
  deb-src *repository* *codename* main
@@ -275,11 +274,10 @@ In case you would like to install QGIS Server, type::
 .. note:: Please remove all the QGIS and GRASS packages you may have
    installed from other repositories before doing the update.
 
-In case of keyserver errors add the qgis.org repository public key to
-your apt keyring, type::
+In case of keyserver errors, download the qgis.org repository public key with::
 
- wget -O - https://qgis.org/downloads/qgis-2022.gpg.key | gpg --import
- gpg --fingerprint D155B8E6A419C5BE
+ wget https://qgis.org/downloads/qgis-2022.gpg.key
+ gpg --show-keys qgis-2022.gpg.key
 
 Should output::
 
@@ -287,16 +285,13 @@ Should output::
        2D7E 3441 A707 FDB3 E705  9441 D155 B8E6 A419 C5BE
  uid           [ unknown] QGIS Archive Automatic Signing Key (2022-2027) <qgis-developer@lists.osgeo.org>
 
-After you have verified the fingerprint you can add the key to apt with::
+After you have verified the fingerprint you can install the key with::
 
- gpg --export --armor D155B8E6A419C5BE | sudo gpg --no-default-keyring --keyring gnupg-ring:/etc/apt/trusted.gpg.d/qgis-archive.gpg --import
- sudo chmod a+r /etc/apt/trusted.gpg.d/qgis-archive.gpg
+ sudo gpg --yes -o /usr/share/keyrings/qgis-archive.gpg --dearmor qgis-2022.gpg.key
 
-Alternatively you can download the key from a keyserver and add the key to apt
-in without manual fingerprint verification::
+Alternatively you can download the key from a keyserver without manual fingerprint verification::
         
- wget -qO - https://qgis.org/downloads/qgis-2022.gpg.key | sudo gpg --no-default-keyring --keyring gnupg-ring:/etc/apt/trusted.gpg.d/qgis-archive.gpg --import
- sudo chmod a+r /etc/apt/trusted.gpg.d/qgis-archive.gpg
+ wget -O- https://qgis.org/downloads/qgis-2022.gpg.key | sudo gpg --dearmor --yes -o /usr/share/keyrings/qgis-archive.gpg
 
 
 Fedora


### PR DESCRIPTION
Here is proposed changes to follow guidelines for third party repositories on Ubuntu and Debian according to https://wiki.debian.org/DebianRepository/UseThirdParty.

Fixes #947 too
