### PR TITLE
Fix Flatpak install commands

### DIFF
--- a/source/site/forusers/alldownloads.rst
+++ b/source/site/forusers/alldownloads.rst
@@ -464,7 +464,7 @@ QGIS on Flathub: https://flathub.org/apps/details/org.qgis.qgis
 
 To install::
 
- flatpak install --from  https://flathub.org/repo/appstream/org.qgis.qgis.flatpakref
+ flatpak install --from  https://dl.flathub.org/repo/appstream/org.qgis.qgis.flatpakref
 
 Then to run::
 
@@ -478,9 +478,9 @@ On certain distributions, you may also need to install xdg-desktop-portal or xdg
 
 Flathub files: https://github.com/flathub/org.qgis.qgis and report issues here: https://github.com/flathub/org.qgis.qgis/issues
 
-Note: if you need to install additional Python modules, because they are needed by a plugin, you can install the module with (here installing the urllib3 module)::
+Note: if you need to install additional Python modules, because they are needed by a plugin, you can install the module with (here installing the scipy module)::
 
- flatpak run --devel --command=pip3 org.qgis.qgis install urllib3 --user
+ flatpak run --devel --command=pip3 org.qgis.qgis install scipy --user
 
 
 Mac OS X / macOS

--- a/source/site/forusers/alldownloads.rst
+++ b/source/site/forusers/alldownloads.rst
@@ -464,7 +464,7 @@ QGIS on Flathub: https://flathub.org/apps/details/org.qgis.qgis
 
 To install::
 
- flatpak install --from  https://dl.flathub.org/repo/appstream/org.qgis.qgis.flatpakref
+ flatpak install --from https://dl.flathub.org/repo/appstream/org.qgis.qgis.flatpakref
 
 Then to run::
 


### PR DESCRIPTION
Changes https://flathub.org/repo/appstream/org.qgis.qgis.flatpakref to https://dl.flathub.org/repo/appstream/org.qgis.qgis.flatpakref. See https://github.com/qgis/QGIS-Website/issues/1022.

Changes also the instructions to install additional Python modules, using the scipy module (as in https://github.com/flathub/org.qgis.qgis/blob/master/README.md) instead of the urllib3 module since the latter is currently already available in the Flatpak installation.