### PR TITLE
WIP: Download page simplification proposal

### DIFF
--- a/themes/qgis-theme/forusers_download.html
+++ b/themes/qgis-theme/forusers_download.html
@@ -67,8 +67,8 @@
                             <li class="download-text">sha256</li>
                           </ul>
                         </a>
-                        <p>{{ _('Standalone installers are recommended for new users.') }} </p>
-                        <p><i>{{ _('Note that the MSI installers are much bigger than the previous installers. This is because they include significant larger packages (eg. PROJ 8).  The main reason for the switch to MSI were the size limits previously used NSIS has, which was blocking updates of dependencies.') }}</i><br/><br/></p>
+                        <p><i>{{ _('Standalone installers are recommended for new users.') }} </i></p>
+                      
                       </div>
                       <div>
                         <h6>{{ _('All in one OSGeo4W installer :') }}</h6>

--- a/themes/qgis-theme/forusers_download.html
+++ b/themes/qgis-theme/forusers_download.html
@@ -37,7 +37,41 @@
                   <div id="windows" class="accordion-body collapse in">
                     <div class="accordion-inner">
                       <div>
-                        <h5>{{ _('QGIS in OSGeo4W (recommended for regular users):') }}</h5>
+                        <h6>{{ _('Latest release, richest on features:') }}</h6>
+                        <a href="https://qgis.org/downloads/QGIS-OSGeo4W-{{ release|e }}-{{ binary|e }}.msi" class="reference external">
+                          <ul class="inline download-row">
+                            <li><i class="icon-download-alt icon-large"></i></li>
+                            <li class="{{ "qgis{}-download".format( "2" if version.startswith("2.") else "" ) }}"></li>
+                            <li class="download-text">{{ _('QGIS Standalone Installer Version %s')|format( version ) }}</li>
+                          </ul>
+                        </a>
+                        <a href="https://qgis.org/downloads/QGIS-OSGeo4W-{{ release|e }}-{{ binary|e }}.sha256sum" class="reference external button">
+                          <ul class="inline download-row">
+                            <li></li>
+                            <li></li>
+                            <li class="download-text">sha256</li>
+                          </ul>
+                        </a>
+                        <h6>{{ _('Looking for long term support ? :') }}</h6>
+                        <a href="https://qgis.org/downloads/QGIS-OSGeo4W-{{ ltrrelease|e }}-{{ ltrbinary|e }}.msi" class="reference external">
+                          <ul class="inline download-row">
+                            <li><i class="icon-download-alt icon-large"></i></li>
+                            <li class="{{ "qgis{}-download".format( "2" if ltrversion.startswith("2.") else "" ) }}"></li>
+                            <li class="download-text">{{ _('QGIS Standalone Installer Version %s')|format( ltrversion ) }}</li>
+                          </ul>
+                        </a>
+                        <a href="https://qgis.org/downloads/QGIS-OSGeo4W-{{ ltrrelease|e }}-{{ ltrbinary|e }}.sha256sum" class="reference external button">
+                          <ul class="inline download-row">
+                            <li></li>
+                            <li></li>
+                            <li class="download-text">sha256</li>
+                          </ul>
+                        </a>
+                        <p>{{ _('Standalone installers are recommended for new users.') }} </p>
+                        <p><i>{{ _('Note that the MSI installers are much bigger than the previous installers. This is because they include significant larger packages (eg. PROJ 8).  The main reason for the switch to MSI were the size limits previously used NSIS has, which was blocking updates of dependencies.') }}</i><br/><br/></p>
+                      </div>
+                      <div>
+                        <h6>{{ _('All in one OSGeo4W installer :') }}</h6>
                         <a href="https://download.osgeo.org/osgeo4w/v2/osgeo4w-setup.exe" class="reference external">
                         <ul class="inline download-row">
                           <li><i class="icon-large icon-download-alt"></i></li>
@@ -45,48 +79,15 @@
                           <li class="download-text">{{ _('OSGeo4W Network Installer') }}</li>
                         </ul>
                         </a>
+                        <p>{{_('OSGeo4W installer allows to have several QGIS versions in one place, and update each library without downloading the whole package. It is recommended for regular users or organizations deployment.')}}</p>
                         <p>
-			{{ _('In the installer choose ') }}<strong>{{ _('Express Install') }}</strong> {{ _('and select') }} <strong>{{ _('QGIS') }}</strong> {{ _('to install the <em>latest release</em> or ') }} <strong> {{ _('QGIS LTR') }} </strong> {{ _('to install the <em>long term release</em>.') }}<br/>
-			{{ _('The express installations have several optional packages including non-free software. To avoid those you have to use the') }} <strong>{{ _('Advanced Install') }}</strong> {{ _('and choose') }} <strong> qgis </strong> {{ _('and/or') }} <strong> qgis-ltr </strong> {{ _('in the desktop section.') }}<br/> <br/>
-<!--
-			<strong><font color="red"><em>{{ _('CAUTION') }}:</em></font></strong> {{ _('Upgrades of old setups from OSGeo4W v1 using this repository are not supported. You need to do a fresh install or use a different directory.') }}<br/>
-			<strong><font color="red"><em>{{ _('CAUTION') }}:</em></font></strong> {{ _('32 bit binaries are not produced anymore.  Also Windows 7 no longer works as we are now using Python 3.9, which dropped support for it.') }}<br/>
--->
+      {{ _('In the installer choose ') }}<strong>{{ _('Express Install') }}</strong> {{ _('and select') }} <strong>{{ _('QGIS') }}</strong> {{ _('to install the <em>latest release</em> or ') }} <strong> {{ _('QGIS LTR') }} </strong> {{ _('to install the <em>long term release</em>.') }}<br/>
+      {{ _('The express installations have several optional packages including non-free software. To avoid those you have to use the') }} <strong>{{ _('Advanced Install') }}</strong> {{ _('and choose') }} <strong> qgis </strong> {{ _('and/or') }} <strong> qgis-ltr </strong> {{ _('in the desktop section.') }}
+      <!--
+      <strong><font color="red"><em>{{ _('CAUTION') }}:</em></font></strong> {{ _('Upgrades of old setups from OSGeo4W v1 using this repository are not supported. You need to do a fresh install or use a different directory.') }}<br/>
+      <strong><font color="red"><em>{{ _('CAUTION') }}:</em></font></strong> {{ _('32 bit binaries are not produced anymore.  Also Windows 7 no longer works as we are now using Python 3.9, which dropped support for it.') }}<br/>
+      -->
                       <br/>
-                      </div>
-                      <div>
-                        <h5>{{ _('Standalone installers (MSI) from OSGeo4W packages (recommended for new users)') }}</h5>
-                        <h6>{{ _('Latest release (richest on features):') }}</h6>
-                        <a href="https://qgis.org/downloads/QGIS-OSGeo4W-{{ release|e }}-{{ binary|e }}.msi" class="reference external">
-                          <ul class="inline download-row">
-                              <li><i class="icon-download-alt icon-large"></i></li>
-                              <li class="{{ "qgis{}-download".format( "2" if version.startswith("2.") else "" ) }}"></li>
-                              <li class="download-text">{{ _('QGIS Standalone Installer Version %s')|format( version ) }}</li>
-                          </ul>
-                        </a>
-                        <a href="https://qgis.org/downloads/QGIS-OSGeo4W-{{ release|e }}-{{ binary|e }}.sha256sum" class="reference external button">
-                          <ul class="inline download-row">
-                              <li></li>
-                              <li></li>
-                              <li class="download-text">sha256</li>
-                          </ul>
-                        </a>
-                        <h6>{{ _('Long term release (most stable):') }}</h6>
-                        <a href="https://qgis.org/downloads/QGIS-OSGeo4W-{{ ltrrelease|e }}-{{ ltrbinary|e }}.msi" class="reference external">
-                          <ul class="inline download-row">
-                              <li><i class="icon-download-alt icon-large"></i></li>
-                              <li class="{{ "qgis{}-download".format( "2" if ltrversion.startswith("2.") else "" ) }}"></li>
-                              <li class="download-text">{{ _('QGIS Standalone Installer Version %s')|format( ltrversion ) }}</li>
-                          </ul>
-                        </a>
-                        <a href="https://qgis.org/downloads/QGIS-OSGeo4W-{{ ltrrelease|e }}-{{ ltrbinary|e }}.sha256sum" class="reference external button">
-                          <ul class="inline download-row">
-                              <li></li>
-                              <li></li>
-                              <li class="download-text">sha256</li>
-                          </ul>
-                        </a>
-			<p>{{ _('Note that the MSI installers are much bigger than the previous installers.  This is because they include significant larger packages (eg. PROJ 8).  The main reason for the switch to MSI were the size limits previously used NSIS has, which was blocking updates of dependencies.') }}</p>
                       </div>
                     </div>
                   </div>

--- a/themes/qgis-theme/forusers_download.html
+++ b/themes/qgis-theme/forusers_download.html
@@ -81,8 +81,6 @@
                         </a>
                         <p>{{_('OSGeo4W installer allows to have several QGIS versions in one place, and update each library without downloading the whole package. It is recommended for regular users or organizations deployment.')}}</p>
                         <p>
-      {{ _('In the installer choose ') }}<strong>{{ _('Express Install') }}</strong> {{ _('and select') }} <strong>{{ _('QGIS') }}</strong> {{ _('to install the <em>latest release</em> or ') }} <strong> {{ _('QGIS LTR') }} </strong> {{ _('to install the <em>long term release</em>.') }}<br/>
-      {{ _('The express installations have several optional packages including non-free software. To avoid those you have to use the') }} <strong>{{ _('Advanced Install') }}</strong> {{ _('and choose') }} <strong> qgis </strong> {{ _('and/or') }} <strong> qgis-ltr </strong> {{ _('in the desktop section.') }}
       <!--
       <strong><font color="red"><em>{{ _('CAUTION') }}:</em></font></strong> {{ _('Upgrades of old setups from OSGeo4W v1 using this repository are not supported. You need to do a fresh install or use a different directory.') }}<br/>
       <strong><font color="red"><em>{{ _('CAUTION') }}:</em></font></strong> {{ _('32 bit binaries are not produced anymore.  Also Windows 7 no longer works as we are now using Python 3.9, which dropped support for it.') }}<br/>


### PR DESCRIPTION
Hi all, 
following some discussions at the hackfest with @mbernasocchi @m-kuhn , I tried to patch the existing page to do a minor overhaul . 
The idea is to have a much simpler download page for windows with one main installer clearly visible. Blender download page is really nice for this :  

![image](https://user-images.githubusercontent.com/1629853/185798509-59ea505d-1b0d-4710-9fae-69fe0b7be8ca.png)

Here is a first comparison screenshot , I will keep on removing text and complexities, but we'll need a front end guru to polish this (hi @faebebin :wave:  ) if you think this is worth it. 

![download_windows_option_1](https://user-images.githubusercontent.com/1629853/185799690-f906988c-a12f-4f19-8d68-3c6a3f82d719.png)


A long running debate is wether we promote LTR or release first. 

My personal feeling is that Blender is right. New user just want one button pointing to the latest version. GIS admin doing deployment will probably take more time to read and the "Want more stability?" hooking formula sounds nice enough to me. 

any opinion @timlinux @andreasneumann ? 


related issues : https://github.com/qgis/QGIS-Website/issues/858