### PR TITLE
add release dates to changelogs

### DIFF
--- a/source/site/forusers/visualchangelog200/index.rst
+++ b/source/site/forusers/visualchangelog200/index.rst
@@ -5,6 +5,8 @@
 Changelog for QGIS 2.0
 ======================
 
+Release date: 2013-09-20
+
 .. contents::
    :local:
 

--- a/source/site/forusers/visualchangelog210/index.rst
+++ b/source/site/forusers/visualchangelog210/index.rst
@@ -4,6 +4,8 @@
 Changelog for QGIS 2.10
 =======================
 
+Release date: 2015-07-21
+
 This is the change log for the next release of QGIS - version 2.10.0 '
 Pisa' - host city to our developer meet up in March 2010.
 

--- a/source/site/forusers/visualchangelog212/index.rst
+++ b/source/site/forusers/visualchangelog212/index.rst
@@ -5,6 +5,7 @@ Changelog for QGIS 2.12
 
 |image1|
 
+Release date: 2015-10-26
 
 This is the change log for the next release of QGIS - version 2.12.0
 'Lyon' - host city to our developer meet up in April 2012.

--- a/source/site/forusers/visualchangelog214/index.rst
+++ b/source/site/forusers/visualchangelog214/index.rst
@@ -6,6 +6,8 @@ Changelog for QGIS 2.14
 
 |image1|
 
+Release date: 2016-02-29
+
 This is the changelog for the next release of QGIS - version 2.14 'Essen'.
 Essen was the host city to our developer meet ups in October 2012 and 2014.
 

--- a/source/site/forusers/visualchangelog216/index.rst
+++ b/source/site/forusers/visualchangelog216/index.rst
@@ -6,6 +6,8 @@ Changelog for QGIS 2.16
 
 |image1|
 
+Release date: 2016-07-22
+
 This is the log for the next release of QGIS - version 2.16.0 'Nødebo'.
 The Department of Geoscience and Natural Resource Management
 Forest and Landscape College in Nødebo were hosts to the First International

--- a/source/site/forusers/visualchangelog218/index.rst
+++ b/source/site/forusers/visualchangelog218/index.rst
@@ -6,6 +6,7 @@ Changelog for QGIS 2.18
 
 |image1|
 
+Release date: 2016-11-03
 
 This is the last release in the 2.x series. The current Long Term Release (LTR) remains version 2.14.x. 
 This release provides incremental improvements over our previous release. 

--- a/source/site/forusers/visualchangelog220/index.rst
+++ b/source/site/forusers/visualchangelog220/index.rst
@@ -4,6 +4,8 @@
 Changelog for QGIS 2.2
 ======================
 
+Release date: 2014-02-22
+
 Change log for the next release of QGIS 2.2.0. The emphasis on this
 release has been very much on polish and performance - we have added
 many new features, tweaks and enhancements to make the user interface

--- a/source/site/forusers/visualchangelog240/index.rst
+++ b/source/site/forusers/visualchangelog240/index.rst
@@ -3,6 +3,8 @@
 Changelog for QGIS 2.4
 ======================
 
+Release date:  2014-06-27
+
 Change log for the next release of QGIS 2.4.0. The emphasis on this
 release has been very much on polish and performance - we have added
 many new features, tweaks and enhancements to make the user interface

--- a/source/site/forusers/visualchangelog260/index.rst
+++ b/source/site/forusers/visualchangelog260/index.rst
@@ -3,6 +3,8 @@
 Changelog for QGIS 2.6
 ======================
 
+Release date: 2014-11-01
+
 Change log for the next release of QGIS 2.6.0. We have added many new
 features, tweaks and enhancements to make the most popular Free desktop
 GIS even more feature filled and useful.

--- a/source/site/forusers/visualchangelog28/index.rst
+++ b/source/site/forusers/visualchangelog28/index.rst
@@ -4,6 +4,8 @@
 Changelog for QGIS 2.8
 =======================
 
+Release date: 2015-03-02
+
 This is the change log for the next release of QGIS - version 2.8 ' Wien'. Wien is German for 'Vienna' - host city to our developer meet up in November 2009 and again in March 2014.
 
 **Long Term Release**

--- a/source/site/forusers/visualchangelog30/index.rst
+++ b/source/site/forusers/visualchangelog30/index.rst
@@ -6,6 +6,7 @@ Changelog for QGIS 3.0
 
 |image1|
 
+Release date: 2018-02-23
 
 The greatest QGIS release ever! QGIS 3.0 is a huge overhaul and cleanup of our beloved Open Source GIS. QGIS 3.0 brings a massive list of new changes - the highlights of which we will try to cover here. As always can we remind you that QGIS is an open source project and if you are able to, consider supporting our work through `donations <http://www.qgis.org/en/site/getinvolved/donations.html?highlight=donate>`__, `sponsorship <http://www.qgis.org/en/site/getinvolved/governance/sponsorship/sponsorship.html>`__ or contributions to the code documentation, web site and so on.
 

--- a/source/site/forusers/visualchangelog310/index.rst
+++ b/source/site/forusers/visualchangelog310/index.rst
@@ -6,6 +6,8 @@ Changelog for QGIS 3.10
 
 |image1|
 
+Release date: 2019-11-02
+
 QGIS 3.10 brings an extensive list of new changes and a lot of polishing of existing features - the highlights of which we will try to cover here. As always can we remind you that QGIS is an open source project and if you are able to, consider supporting our work through donations or contributions to the code documentation, web site and so on.
 
 **Thanks**

--- a/source/site/forusers/visualchangelog312/index.rst
+++ b/source/site/forusers/visualchangelog312/index.rst
@@ -6,6 +6,8 @@ Changelog for QGIS 3.12
 
 |image1|
 
+Release date: 2020-02-26
+
 If you are after new features and a ton of bug fixes, this release will have you smiling from ear to ear! QGIS 3.12 adds rich new capabilities to almost every part of QGIS. From label masks to a native PG Raster provider to incredible new mesh layer capabilities, and much, much more, this release has something for everyone. As always, we would like to remind you that QGIS is an open-source project and if you are able to, consider supporting our work through donations, sponsorship or contributions to the code documentation, web site and so on.
 
 **Thanks**

--- a/source/site/forusers/visualchangelog314/index.rst
+++ b/source/site/forusers/visualchangelog314/index.rst
@@ -5,6 +5,8 @@ Changelog for QGIS 3.14
 
 |image1|
 
+Release date: 2020-06-25
+
 Another awesome release in the trail of great QGIS releases we have made across 18 years of development. This release is so jam-packed with new features and improvements big and small, it is hard to know where to start. Some of the marquee features include vector tile support, huge advances in mdal / mesh support, native support for temporal data in WMS-T, PG Raster, vector providers, and mesh layers. Users focussed on cartography and digitising haven't been left out either, with many new options for you!
 
 **Thanks**

--- a/source/site/forusers/visualchangelog316/index.rst
+++ b/source/site/forusers/visualchangelog316/index.rst
@@ -5,6 +5,8 @@ Changelog for QGIS 3.16
 
 |image1|
 
+Release date: 2020-10-27
+
 Another great day for the QGIS project! The new long term support release brings a wide range of features to both QGIS Desktop and QGIS Server. This release brings a wealth of new options for 3D mapping, mesh generation from other data types, additional spatial analysis tools, symbology and user interface enhancements to name but a few! A host of tools have been incorporated into the ever-expanding processing framework, and the QGIS browser now supports advanced database interaction functionality that was previously reserved for the DB Manager plugin. These are a few of the improvements that have been introduced from this release, and users of the previous LTS will find a massive number of new features available since 3.10. We are pleased to detail some of the additional highlights of this new release below.
 
 **Thanks**

--- a/source/site/forusers/visualchangelog318/index.rst
+++ b/source/site/forusers/visualchangelog318/index.rst
@@ -5,6 +5,8 @@ Changelog for QGIS 3.18
 
 |image1|
 
+Release date: 2021-02-23
+
 Following on from the feature-filled releases of `QGIS 3.14 <https://qgis.org/en/site/forusers/visualchangelog314/>`__ and `QGIS 3.16 <https://qgis.org/en/site/forusers/visualchangelog316/>`__, QGIS 3.18 introduces a host of enhancements and new features, along with a long-awaited feature - Native Point Cloud support in QGIS! Thanks to the efforts of `Lutra <https://www.lutraconsulting.co.uk/>`__, `North Road <https://north-road.com/>`__, and `Hobu <https://hobu.co/>`__, QGIS is now able to import and render point cloud data in various formats by leveraging the Open Source PDAL library. This functionality has been introduced due to the success of a `crowd-funding campaign <https://www.lutraconsulting.co.uk/crowdfunding/pointcloud-qgis/>`__ and would not have been possible without the support of the QGIS community and contributors. Thank you to all those involved in realizing this incredible milestone!
 
 As QGIS Desktop 3.18 bids farewell to the DB2 database provider, it introduces support for users of the SAP HANA database system.

--- a/source/site/forusers/visualchangelog32/index.rst
+++ b/source/site/forusers/visualchangelog32/index.rst
@@ -6,6 +6,8 @@ Changelog for QGIS 3.2
 
 |image1|
 
+Release date: 2018-06-22
+
 The greatest QGIS release ever! QGIS 3.2 brings a massive list of new changes - the highlights of which we will try to cover here. As always can we remind you that QGIS is an open source project and if you are able to, consider supporting our work through `donations <https://donate.qgis.org>`__, :ref:`sustaining memberships <QGIS_sustaining_memberships>` or contributions to the code documentation, web site and so on.
 
 

--- a/source/site/forusers/visualchangelog320/index.rst
+++ b/source/site/forusers/visualchangelog320/index.rst
@@ -5,6 +5,8 @@ Changelog for QGIS 3.20
 
 |image1|
 
+Release date: 2021-06-22
+
 QGIS 3.20 Odense features a splash screen which displays a section of `the earliest map <http://www5.kb.dk/maps/kortsa/2012/jul/kortatlas/object80440/en/>`__ of Denmark’s third largest city, `Odense <https://en.wikipedia.org/wiki/Odense>`__ from 1593. The map was published by `Georg Braun <https://en.wikipedia.org/wiki/Georg_Braun>`__ (1541-1622) in the work *Civitates orbis terrarum* (Cities of the World). Georg Braun’s maps are all beautiful and were, for the period, produced at a high cartographic level. *Civitates orbis terrarum* was long the main source of maps of the world’s cities, such as `Paris <http://www5.kb.dk/maps/kortsa/2012/jul/kortatlas/object62269/en/>`__, `London <http://www5.kb.dk/maps/kortsa/2012/jul/kortatlas/object62684/en/>`__, `Mexico City <http://www5.kb.dk/maps/kortsa/2012/jul/kortatlas/object62261/en/>`__ and `Aden <http://www5.kb.dk/maps/kortsa/2012/jul/kortatlas/object62257/en/>`__.
 
 The name Odense literally means “Odin’s temple”, and the place may have originally been a shrine to the pagan god Odin. At the bottom left of the map you see the ruins of one of the large Viking-Age ring-shaped fortress, which were constructed in Denmark by the Danish Viking king `Harald Bluetooth <https://en.wikipedia.org/wiki/Harald_Bluetooth>`__ (died c. 985/86). The ring fortress in Odense is called `Nonnebakken <https://odensebysmuseer.dk/nonnebakken-the-viking-ring-fortress-in-time-and-space/?lang=en>`__.

--- a/source/site/forusers/visualchangelog322/index.rst
+++ b/source/site/forusers/visualchangelog322/index.rst
@@ -5,6 +5,8 @@ Changelog for QGIS 3.22
 
 |image1|
 
+Release date: 2021-10-30
+
 QGIS 3.22 Białowieża is aimed at celebrating the 100-year anniversary of `Białowieża National Park <https://en.wikipedia.org/wiki/Bia%C5%82owie%C5%BCa_National_Park>`__, Poland, which was established in 1921. `Białowieża Forest <https://en.wikipedia.org/wiki/Bia%C5%82owie%C5%BCa_Forest>`__ is one of the world’s last primary woodlands, located on the border between Poland and Belarus. It is one of the few natural old-growth forests in temperate lowland Europe and has been protected for over 600 years. The outstanding value of Białowieża Forest has been acknowledged by its recognition as a `UNESCO Natural World Heritage Site <https://whc.unesco.org/en/list/33>`__.
 
 Białowieża Forest is named after the village Białowieża, which is located right in the middle of this woodland. It is one of the oldest settlements in the area, nowadays hosting numerous research and tourism activities. Today, there are three research institutions in the village: `Białowieża Geobotanical Station, University of Warsaw <https://bsg.bialowieza.pl/en/>`__, `The Mammal Research Institute, Polish Academy of Sciences <https://ibs.bialowieza.pl/en/>`__, and the `Forest Research Institute, Department of Natural Forests <https://www.ibles.pl/en/web/guest/home>`__. Additionally, a large number of scientists from Poland and abroad travel to Białowieża in order to carry out their studies, and as such, there are also other users of QGIS in the area, as well as additional projects which contribute to the Open Data and Open Source Software ecosystems, such as the `Open Forest Data <https://openforestdata.pl/>`__ project.

--- a/source/site/forusers/visualchangelog324/index.rst
+++ b/source/site/forusers/visualchangelog324/index.rst
@@ -5,6 +5,8 @@ Changelog for QGIS 3.24
 
 |image1|
 
+Release date: 2022-02-18
+
 In Memorium: This release is named 'Tisler' after a small Norwegian island that was a favourite visiting place of Håvard Tveite who passed away in May 2021. Håvard was a very active member of the QGIS community, providing valuable input to the documentation, developing numerous plugins, and taking care of the QGIS Resources Sharing Repository to name just a few of his contributions. The map on the QGIS 3.24 splash screen is an orienteering map that Håvard has created. He liked spending some time each year map-making at Tisler.
 
 We would also like to extend a big thank you to the developers, documenters, testers, and all the many folks out there who volunteer their time and effort (or fund people to do so) to make these releases possible. From the QGIS community, we hope you enjoy this release! If you wish to donate time, money, or otherwise get involved in making QGIS more awesome, please wander along to `QGIS.ORG <qgis.org>`__ and lend a hand!

--- a/source/site/forusers/visualchangelog326/index.rst
+++ b/source/site/forusers/visualchangelog326/index.rst
@@ -5,6 +5,8 @@ Changelog for QGIS 3.26
 
 |image1|
 
+Release date: 2022-06-24
+
 The feature-packed release of QGIS 3.26 Buenos Aires includes a vast number of enhancements to a range of advanced core functionalities. This includes numerous improvements to 3D capabilities, improved tooling for point clouds, and the introduction of a new profile plotting framework for the creation of cross-sections and elevation profiles. Best of all, the new plotting framework uses the native QGIS rendering capabilities and comes with all the styling, symbology, and data driven properties we all know and love baked right in!
 
 For a whirlwind tour of all the new functionalities introduced, you can view the highlight reel video on YouTube at https://youtu.be/pZmrw_zR7sA

--- a/source/site/forusers/visualchangelog34/index.rst
+++ b/source/site/forusers/visualchangelog34/index.rst
@@ -6,6 +6,8 @@ Changelog for QGIS 3.4 LTR
 
 |image0|
 
+Release date: 2018-10-28
+
 The first long-term release (LTR) of QGIS 3. QGIS 3.4 just released. After five consolidation point releases (3.4.5) it will replace the previous LTR in the package repositories in February 2019 (see :ref:`release schedule <QGIS-release-schedule>`).
 This is a giant leap forward for the project - our first Long Term Release based on the 3.x platform. For users moving over from the 2.18 LTR there is a huge list of new features and impactful changes in this new LTR version.
 Please bear in mind that 3.x plugins are incompatible with 2.x plugins so review your plugin usage carefully - and if possible help to migrate old plugins to the new platform. If you have not already done so, take a look at the changelogs from :ref:`Version 3.0 <changelog30>` and :ref:`Version 3.2 <changelog32>` to understand the full scope of changes in the 3.4 release.

--- a/source/site/forusers/visualchangelog36/index.rst
+++ b/source/site/forusers/visualchangelog36/index.rst
@@ -6,6 +6,8 @@ Changelog for QGIS 3.6
 
 |image1|
 
+Release date: 2019-02-24
+
 The greatest QGIS release ever! QGIS 3.6 brings a massive list of new changes - the highlights of which we will try to cover here. As always can we remind you that QGIS is an open source project and if you are able to, consider supporting our work through donations, sponsorship or contributions to the code documentation, web site and so on.
 
 Thanks

--- a/source/site/forusers/visualchangelog38/index.rst
+++ b/source/site/forusers/visualchangelog38/index.rst
@@ -5,6 +5,8 @@ Changelog for QGIS 3.8
 
 |image1|
 
+Release date: 2019-07-23
+
 QGIS 3.8 brings an extensive list of new changes and a lot of polishing of existing features - the highlights of which we will try to cover here. As always can we remind you that QGIS is an open source project and if you are able to, consider supporting our work through donations, sponsorship or contributions to the code documentation, web site and so on.
 
 **Thanks**


### PR DESCRIPTION
This adds the release date to the top of each changelog.

Where available, the date was taken from the official announcement on the QGIS blog (or, for earlier releases, the QGIS-Developer e-mail list).