### PR TITLE
Normalize the "Looking for the most stable version? ..." translation string

### DIFF
--- a/themes/qgis-theme/forusers_download.html
+++ b/themes/qgis-theme/forusers_download.html
@@ -78,7 +78,7 @@
                         </div>
                       </a>
                       <a class="secondary-download-link" href="https://qgis.org/downloads/macos/qgis-macos-ltr.dmg">
-                        {{ _('Looking for the most stable version? Get QGIS Version %s')|format( ltrversion ) }} LTR
+                        {{ _('Looking for the most stable version? Get QGIS %s %s')|format( ltrversion, ltrnote ) }}
                       </a>
                       <p><em>{{ _('MacOS High Sierra (10.13) and newer is required. QGIS is not yet notarized as required by macOS Catalina (10.15) security rules. On first launch, please right-click on the QGIS app icon, hold down the Option key, then choose Open.') }}</em></p>
                     </div>


### PR DESCRIPTION
Change https://github.com/qgis/QGIS-Website/blob/9a3fef3025f83602f1047acb834d08e11a6977a2/themes/qgis-theme/forusers_download.html#L81 to
`{{ _('Looking for the most stable version? Get QGIS %s %s')|format( ltrversion, ltrnote ) }}` as in https://github.com/qgis/QGIS-Website/blob/9a3fef3025f83602f1047acb834d08e11a6977a2/themes/qgis-theme/forusers_download.html#L46