### PR TITLE
Up to date transifex client

### DIFF
--- a/.github/workflows/tx_push.yml
+++ b/.github/workflows/tx_push.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch:
 
 
 # Allow one concurrent deployment

--- a/.github/workflows/tx_push.yml
+++ b/.github/workflows/tx_push.yml
@@ -23,6 +23,11 @@ jobs:
         run: |
           pip install -r REQUIREMENTS.txt
 
+      - name: Install Transifex client
+        run: |
+          curl -OL https://github.com/transifex/cli/releases/download/v1.3.1/tx-linux-amd64.tar.gz
+          tar -xvzf tx-linux-amd64.tar.gz
+
       - name: Generate translation sources
         run: |
             make pretranslate
@@ -32,7 +37,7 @@ jobs:
         env:
           TX_TOKEN: ${{ secrets.TX_TOKEN }}
         run: |
-            tx push -s
+            ./tx push -s
 
       - name: Update .tx/config if changed
         run: |

--- a/REQUIREMENTS.txt
+++ b/REQUIREMENTS.txt
@@ -2,7 +2,6 @@ Sphinx==4.5
 sphinx-intl==2.0.1
 sphinx-intl[transifex]
 icalendar
-transifex-client
 PyYAML
 sphinx_rtd_theme
 pdflatex

--- a/scripts/create_transifex_resources.sh
+++ b/scripts/create_transifex_resources.sh
@@ -41,10 +41,11 @@ make springclean
     #echo $RESOURCE
     # Register each po file as a transifex resource (an individual translatable file)
     #set -x
-    tx set -t PO --auto-local -r $RESOURCE \
-      "$GENERICFILE" \
-      --source-lang en \
-      --execute
+    ./tx add \
+        --type PO \
+        --resource $RESOURCE \
+        --source-lang en \
+        "$GENERICFILE"
     #set +x
     # Now register the language translations for the localised po file against
     # this resource.


### PR DESCRIPTION
This PR aims at fixing the problem raised in #1089. It replaces the deprecated Python client with the up-to-date binary executable. It also adds a _workflow_dispatch_ trigger to test the action. No other change should be required (i.e. the current token should be fine).

__To do (after this has received workflow approval)__
- [ ] test push
- [ ] test shell script adding resources