### PR TITLE
Fixing missing TX_TOKEN from tx push

### DIFF
--- a/.github/workflows/tx_push.yml
+++ b/.github/workflows/tx_push.yml
@@ -6,7 +6,6 @@ on:
       - master
   workflow_dispatch:
 
-
 # Allow one concurrent deployment
 concurrency:
   group: "tx_push"
@@ -14,7 +13,6 @@ concurrency:
 
 jobs:
   update:
-
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -31,14 +29,14 @@ jobs:
 
       - name: Generate translation sources
         run: |
-            make pretranslate
-            ./scripts/create_transifex_resources.sh
+          make pretranslate
+          ./scripts/create_transifex_resources.sh
 
       - name: Push translations
         env:
-          TX_TOKEN: ${{ secrets.TX_TOKEN }}
+          tx_token: ${{ secrets.TX_TOKEN }}
         run: |
-            ./tx push -s
+          TX_TOKEN=$tx_token ./tx push -s
 
       - name: Update .tx/config if changed
         run: |


### PR DESCRIPTION
Unfortunately secrets cannot be used from PR originating from forks, as is the case with this PR, so https://github.com/qgis/QGIS-Website/actions/runs/4161847146/jobs/7200299418 does not prove that the TX_TOKEN is invalid. But if the issue persists after merging it might be necessary to regenerate this repository's TX_TOKEN secret.