### PR TITLE
Update backwards compatibility info

### DIFF
--- a/source/site/forusers/visualchangelog328/index.rst
+++ b/source/site/forusers/visualchangelog328/index.rst
@@ -26,6 +26,16 @@ QGIS is free software and you are under no obligation to pay anything to use it 
 .. contents::
    :local:
 
+Breaking Changes
+----------------
+
+Feature: Drop project backward compatibility for symbology with QGIS 3.16 and older
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Previous releases of QGIS would write significant amounts of compatibility objects into the XML structure of project files to maintain backward compatibility for symbologies in order to allow project files to be opened with QGIS 3.16 and older. This compatibility has been removed from future releases.
+
+This feature was developed by `Denis Rouzaud <https://github.com/3nids>`__
+
 Temporal
 --------
 

--- a/source/site/forusers/visualchangelog328/index.rst
+++ b/source/site/forusers/visualchangelog328/index.rst
@@ -32,9 +32,8 @@ Breaking Changes
 Feature: Drop project backward compatibility for symbology with QGIS 3.16 and older
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Previous releases of QGIS would write significant amounts of compatibility objects into the XML structure of project files to maintain backward compatibility for symbologies in order to allow project files to be opened with QGIS 3.16 and older. This compatibility has been removed from future releases.
+Previous releases of QGIS would write significant amounts of compatibility objects into the XML structure of project files to maintain backward compatibility for symbologies in order to allow project files to be opened with QGIS 3.16 and older. This compatibility has been removed from future releases, providing significant optimizations to the project file structure.
 
-This feature was developed by `Denis Rouzaud <https://github.com/3nids>`__
 
 Temporal
 --------

--- a/source/site/forusers/visualchangelog330/index.rst
+++ b/source/site/forusers/visualchangelog330/index.rst
@@ -11,7 +11,6 @@ The 3.30 's-Hertogenbosch release of the groundbreaking QGIS project introduces 
 
 The splash screen features a fragment of the “Gemeentekaart”, or Municipality map, of 's-Hertogenbosch from 1867. It is part of a series of 1200 maps of all the communities in The Netherlands from that time, which were published in an atlas for each of the 11 regions. All maps were drawn in the same size, although for large municipalities a double format was used and scaled to match the page. The series was internationally rewarded because of its accuracy and completeness. The map was drawn by Jacob Kuyper (1821-1908), the most famous geographer and cartographer of his time in The Netherlands. Text and splash map image provided by `atlasandmap.com <https://atlasandmap.com>`__
 
-Importantly, support for backward compatibility of Symbol Styling has been removed for QGIS 3.16, providing significant optimizations to the project file structure, but limiting the capability of older releases of QGIS for rendering symbologies developed with later releases.
 
 The native GeoNode integration has also been migrated to an external plugin, leveraging the powerful extensions to the QGIS API for plugins implemented in recent releases.
 

--- a/source/site/forusers/visualchangelog330/index.rst
+++ b/source/site/forusers/visualchangelog330/index.rst
@@ -11,7 +11,7 @@ The 3.30 's-Hertogenbosch release of the groundbreaking QGIS project introduces 
 
 The splash screen features a fragment of the “Gemeentekaart”, or Municipality map, of 's-Hertogenbosch from 1867. It is part of a series of 1200 maps of all the communities in The Netherlands from that time, which were published in an atlas for each of the 11 regions. All maps were drawn in the same size, although for large municipalities a double format was used and scaled to match the page. The series was internationally rewarded because of its accuracy and completeness. The map was drawn by Jacob Kuyper (1821-1908), the most famous geographer and cartographer of his time in The Netherlands. Text and splash map image provided by `atlasandmap.com <https://atlasandmap.com>`__
 
-Importantly, support for backward compatibility of Symbol Styling has been removed for QGIS 3.16, providing significant optimizations to the project file structure, but limiting the capability of older releases of QGIS for rendering symbologies developed with later releases. This change has been ported to the release of 3.28 LTR as well.
+Importantly, support for backward compatibility of Symbol Styling has been removed for QGIS 3.16, providing significant optimizations to the project file structure, but limiting the capability of older releases of QGIS for rendering symbologies developed with later releases.
 
 The native GeoNode integration has also been migrated to an external plugin, leveraging the powerful extensions to the QGIS API for plugins implemented in recent releases.
 


### PR DESCRIPTION
Update the backward compatibility info for 3.16 symbologies, as discussed in https://github.com/qgis/QGIS/pull/45143