### PR TITLE
Simplify and sort packages we rely on

### DIFF
--- a/.github/workflows/html.yml
+++ b/.github/workflows/html.yml
@@ -12,10 +12,10 @@ jobs:
       name: Checking out the code 🛒
       with:
         fetch-depth: 1
-    - name: Set up Python 3.7 🐍
+    - name: Set up Python 3.10 🐍
       uses: actions/setup-python@v4
       with:
-        python-version: 3.7
+        python-version: '3.10'
     - name: Install dependencies 👨‍👩‍👦
       run: |
           python -m pip install --upgrade pip

--- a/REQUIREMENTS.txt
+++ b/REQUIREMENTS.txt
@@ -1,11 +1,10 @@
-Sphinx==4.5
-sphinx-intl==2.0.1
 icalendar
-PyYAML
-sphinx_rtd_theme
 pdflatex
-sphinxext-rediraffe
-sphinx_togglebutton
+pyYAML
 requests==2.25.1
+Sphinx==7.2.6
 sphinx_copybutton
-
+sphinx-intl
+sphinx_rtd_theme
+sphinx_togglebutton
+sphinxext-rediraffe


### PR DESCRIPTION
* Lock readthedocs theme version instead of sphinx
* Remove sphinx from the list, as part of dependencies for many others
* Unlock sphinx-intl version, and avoid build warning message due to deprecated process