### PR TITLE
Transifex changes how to reach their platform

### DIFF
--- a/themes/qgis-theme/languageswitch.html
+++ b/themes/qgis-theme/languageswitch.html
@@ -65,7 +65,7 @@
         // IMPORTANT: space, -, _ etc replacing below must be 100% inline with
         // code in scripts/create_transifex_resources.sh !!
         // https://github.com/qgis/QGIS-Website/blob/master/scripts/create_transifex_resources.sh
-        fix_translation_link = 'https://www.transifex.com/projects/p/qgis-website/translate/#' + 
+        fix_translation_link = 'https://app.transifex.com/qgis/qgis-website/translate/#' + 
             currentLang.slice(1) + currentPage.replace(/_/g, "-").replace(/ /g, "-").replace(/\//g, "_").replace(/\.html/g, "").replace(/\./g, "-")
         if ('/en/' != currentLang) {
             $('#fix_translation_link').attr('href', fix_translation_link);


### PR DESCRIPTION
The link at the bottom of the pages does not bring you to the resource to translate
https://help.transifex.com/en/articles/7171815-web-application-s-domain-change and the way to build path has changed but seems it still works for the website repo