### PR TITLE
Updated links for Datapolitan classes to new cont

### DIFF
--- a/source/site/forusers/trainingmaterial/index.rst
+++ b/source/site/forusers/trainingmaterial/index.rst
@@ -30,11 +30,10 @@ https://www.qgistutorials.com/
 Tutorial material, originally developed as part of a workshop for the Ecology and Evolutionary Biology Program at Texas A&M University (produced and maintained by Mike Treglia):
 http://mltconsecol.github.io/QGIS-Tutorial/
 
-In-person training material, originally developed for the New York City Department of Transportation by `Datapolitan <http://www.datapolitan.com>`_:
+In-person training material, originally developed for the New York City Department of Transportation by `Datapolitan <http://www.datapolitan.com>`_. Available for self-study and re-use:
 
-* `Introduction to GIS Fundamentals <http://training.datapolitan.com/qgis-training/Introduction_to_GIS_Fundamentals>`_
-* `Intermediate GIS with QGIS and PostGIS <http://training.datapolitan.com/qgis-training/Intermediate_GIS/>`_
-* `Source code for training materials <https://github.com/Datapolitan-Training/qgis-training>`_
+* `Introduction to GIS Fundamentals <https://bit.ly/intro-gis-fundamentals>`_
+* `Intermediate GIS with QGIS and PostGIS <http://bit.ly/intermediate-gis>`_
 
 Online course material for QGIS training developed and maintained by `Spatial Thoughts <http://spatialthoughts.com/>`_. Available for self-study and adaptation by other trainers:
 


### PR DESCRIPTION
The classes were recently updated to fix broken links and missing content. The new links point to the new site for the materials on Github. Also updating the description to clearly state availability for self-study and re-use. 

Note: the short URL for the Intermediate class won't link to the right content until 1 May, but once that's fixed, it will point to this site: https://training.datapolitan.com/intermediate-gis/#1. Using the bitlinks will keep the links fresh so this shouldn't happen again.