### PR TITLE
Update qugsnews.atom

### DIFF
--- a/source/feeds/qugsnews.atom
+++ b/source/feeds/qugsnews.atom
@@ -17,6 +17,14 @@
 
   -->
   
+  <entry>
+    <id>https://qgis.org</id>
+    <title type="text">4º Encontro De Utilizadores QGIS Portugal</title>
+    <link href="https://www.qgis.pt/encontro-utilizadores-qgis-2023" rel="alternate"> </link>
+    <author> <name>No Author</name> </author>
+    <updated>1970-01-01T00:00:00.000Z</updated>
+    <content type="text">26 de Maio 2023, Évora</content>
+  </entry>
 
 
   <entry>
@@ -32,7 +40,7 @@
  <!--
  
    
-    <entry>
+  <entry>
     <id>https://qgis.org</id>
     <title type="text">Rencontres des Utilisateurs Francophones de QGIS - édition 2023</title>
     <link href="https://conf.qgis.osgeo.fr/" rel="alternate"> </link>
@@ -62,17 +70,6 @@
     <content type="text">from 18 to 22 August, right before FOSS4G Firenze 2022</content>
   </entry>
 
- 
- 
-
-  <entry>
-    <id>https://qgis.org</id>
-    <title type="text">25th QGIS User Conference and Developer Meeting in Nødebo, August 8-23 2020</title>
-    <link href="https://github.com/qgis/QGIS/wiki/25th-Developer-Meeting-in-N%C3%B8debo,-Denmark" rel="alternate"> </link>
-    <author> <name>No Author</name> </author>
-    <updated>1970-01-01T00:00:00.000Z</updated>
-    <content type="text">25th QGIS User Conference and Developer Meeting in Nødebo</content>
-  </entry>
   
 -->
 


### PR DESCRIPTION
This PR has the following changes:
Remove an old event (2020)
Add a QGIS-PT Users event.