### PR TITLE
Update alldownloads.rst for Ubuntu Lunar

### DIFF
--- a/source/site/forusers/alldownloads.rst
+++ b/source/site/forusers/alldownloads.rst
@@ -278,17 +278,16 @@ Supported distribution versions:
 |               +----------------+------------+-----------------------+
 |               | unstable       | sid        |                       |
 +---------------+----------------+------------+-----------------------+
-| Ubuntu        | 23.04          | lunar [6]_ |                       |
+| Ubuntu        | 23.04          | lunar      |                       |
 |               +----------------+------------+-----------------------+
 |               | 22.10          | kinetic    |                       |
 |               +----------------+------------+-----------------------+
 |               | 22.04 (LTS)    | jammy      | yes                   |
 |               +----------------+------------+-----------------------+
-|               | 20.04 (LTS)    | focal [7]_ | yes                   |
+|               | 20.04 (LTS)    | focal [6]_ | yes                   |
 +---------------+----------------+------------+-----------------------+
 
-.. [6] only nightlies builds
-.. [7] only up to QGIS 3.26 (Qt 5.13 required for 3.27)
+.. [6] only up to QGIS 3.26 (Qt 5.13 required for 3.27)
 
 To use the qgis archive you have to first add the archive's repository public key::
 


### PR DESCRIPTION
It seems to me that regular releases for Ubuntu Lunar 23.04 are available, not only nightlies. @jef-n, could you please confirm?