### PR TITLE
Update alldownloads.rst

### DIFF
--- a/source/site/forusers/alldownloads.rst
+++ b/source/site/forusers/alldownloads.rst
@@ -472,7 +472,7 @@ Arch Linux
 QGIS stable
 ...........
 
-Arch Linux is available in official repository : https://www.archlinux.org/packages/community/x86_64/qgis/
+Arch Linux is available in official repository : https://archlinux.org/packages/extra/x86_64/qgis/
 
 Install with::
 


### PR DESCRIPTION
Updated URL for official Arch Linux QGIS package. Current URL points to 404 Page since Community repository has been merged to Extra.