### PR TITLE
downloads: add note on concurrent use of MacPorts and Homebrew

### DIFF
--- a/source/site/forusers/alldownloads.rst
+++ b/source/site/forusers/alldownloads.rst
@@ -561,6 +561,10 @@ Update::
   sudo port selfupdate
   sudo port upgrade outdated
 
+.. note:: Concurrent installation of Homebrew and MacPorts is not compatible
+   and will almost certainly lead to conflicts. If you choose to install one
+   of the package systems you need to uninstall the other.
+
 
 Old releases
 ------------


### PR DESCRIPTION
I have experienced a number of users having problems with installing QGIS on MacPorts. The reason is a conflict with installed Homebrew. This PR suggest to add a note on this matter.