### PR TITLE
Follow-up #1190 (all downloads: add Spack to Linux installation methods)

### DIFF
--- a/themes/qgis-theme/forusers_download.html
+++ b/themes/qgis-theme/forusers_download.html
@@ -106,6 +106,7 @@
                       <li><a href="{{ pathto('site/forusers/alldownloads') }}#slackware">{{ _('Slackware') }}</a></li>
                       <li><a href="{{ pathto('site/forusers/alldownloads') }}#arch-linux">{{ _('Arch Linux') }}</a></li>
                       <li><a href="{{ pathto('site/forusers/alldownloads') }}#flatpak">{{ _('Flatpak') }}</a></li>
+                      <li><a href="{{ pathto('site/forusers/alldownloads') }}#spack">{{ _('Spack') }}</a></li>
                       </ul>
                       <p class="download-text"><a href="{{ pathto('site/forusers/alldownloads') }}#linux">{{ _('Linux Installation Instructions') }}</a></p>
                     </div>


### PR DESCRIPTION
Follow-up https://github.com/qgis/QGIS-Website/pull/1190.