### PR TITLE
Adapt alldownloads.rst to install on LMDE (Linux Mint Debian Edition)

### DIFF
--- a/source/site/forusers/alldownloads.rst
+++ b/source/site/forusers/alldownloads.rst
@@ -163,6 +163,7 @@ Add the QGIS repo for the latest stable QGIS (|version|.x |codename|) to ``/etc/
 .. note:: ``Suites`` in above lines depends on your distribution. ``lsb_release -cs`` will show your distribution name.
 
    In some distributions (like Linux Mint), ``. /etc/os-release; echo "$UBUNTU_CODENAME"`` will show the correct distibution name.
+   In LMDE (Linux Mint Debian Edition), ``. /etc/os-release; echo "$DEBIAN_CODENAME"`` will show the correct distibution name.
 
    See `Available codenames`_.
 


### PR DESCRIPTION
In Linux Mint distribution, the variable to print the distribution name is in general $UBUNTU_CODENAME, but for LMDE (Linux Mint Debian Edition), it is $DEBIAN_CODENAME.