### PR TITLE
Fix yeartag in FAQ - How to cite QGIS

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -229,7 +229,7 @@ rst_epilog = docs_rst_epilog + f"""
 .. |checkbox_unchecked| image:: /static/site/common/checkbox_unchecked.png
 .. |QG| replace:: QGIS
 .. |qg| replace:: QGIS
-.. |yeartag| date:: %%Y
+.. |yeartag| date:: %Y
 .. |devcite| raw:: html
 
      <a href="https://docs.qgis.org/{ltrversion}/en/docs/developers_guide/index.html"> https://docs.qgis.org/{ltrversion}/en/docs/developers_guide/index.html</a>


### PR DESCRIPTION
After https://github.com/qgis/QGIS-Website/commit/7f0cbe674549dfe9db84b6fa69e60f0553672379#diff-7fb09d9c93c5b9e807628c723d479e34bb753665a1cb1cbc1c3b09e4768789a5R221, for rst_epilog variable it is used an f-string instead of the previously used old %-string, so there is no longer the need to escape `%` as `%%`.

Fixes https://github.com/qgis/QGIS-Website/issues/1237.