### PR TITLE
Display the actual available versions for macOS

### DIFF
--- a/themes/qgis-theme/forusers_download.html
+++ b/themes/qgis-theme/forusers_download.html
@@ -84,11 +84,11 @@
                       <a class="reference btn btn-large btn-success" href="https://qgis.org/downloads/macos/qgis-macos-pr.dmg">
                         <div class="primary-download-button">
                           <div class="qgis-download"></div>
-                          <div class="download-text">{{ _('Download QGIS %s')|format( version ) }}</div>
+                          <div class="download-text">{{ _('Download QGIS %s')|format( '3.36.3' ) }}</div>
                         </div>
                       </a>
                       <a class="reference secondary-download-link" href="https://qgis.org/downloads/macos/qgis-macos-ltr.dmg">
-                        {{ _('Looking for the most stable version? Get QGIS %s %s')|format( ltrversion, ltrnote ) }}
+                        {{ _('Looking for the most stable version? Get QGIS %s %s')|format( '3.34.7', ltrnote ) }}
                       </a>
                     </div>
                     <div class="accordion-inner">


### PR DESCRIPTION
Since they are currently not up-to-date and only 3.36.3 and 3.34.7 are available for macOS instead of 3.38.0 and 3.34.8.

Fixes #1258.